### PR TITLE
chore: restore Laravel 9 and PHP 8.0 requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
 
   "require": {
-    "php": "^8.2",
+    "php": "^8.0",
     "aloha/twilio": "^4.0",
     "arcanedev/log-viewer": "9.x",
     "automattic/woocommerce": "^3.0",
@@ -23,7 +23,7 @@
     "giggsey/libphonenumber-for-php": "^8.12",
     "guzzlehttp/guzzle": "^7.2",
     "knox/pesapal": "1.5",
-    "laravel/framework": "^12.0",
+    "laravel/framework": "^9.51",
     "laravel/legacy-factories": "^1.3",
     "laravel/passport": "11.6.1",
     "laravel/tinker": "^2.7",


### PR DESCRIPTION
## Summary
- revert composer.json to require PHP ^8.0 and Laravel Framework ^9.51

## Testing
- `composer validate --no-ansi --no-interaction`
- `php vendor/bin/phpunit --filter DemandForecastServiceTest --testdox` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6c92e7d48332a1976d51d8a94322