### PR TITLE
Add build workflow for Laravel project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build Laravel Project
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, bcmath, pdo_mysql, xml, ctype, curl, json, openssl, tokenizer
+          coverage: none
+
+      - name: Authenticate Composer with GitHub
+        run: composer config --global github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Composer dependencies
+        run: composer update --no-dev --optimize-autoloader
+
+      - name: Run Laravel optimize commands
+        run: |
+          php artisan config:cache
+          php artisan route:cache
+          php artisan view:cache
+
+      - name: Archive build
+        run: zip -r build.zip . -x ".git/*" "tests/*"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: laravel-build
+          path: build.zip
+


### PR DESCRIPTION
## Summary
- add build workflow to automate Laravel project packaging and upload
- authenticate Composer with GitHub token and cache config, route, and view data for production builds

## Testing
- `npm test`
- `php vendor/bin/phpunit` *(fails: Expected response status 200 but got 404)*

------
https://chatgpt.com/codex/tasks/task_e_68bb77bdc5fc8332a03dea3fc05198fd