### PR TITLE
Add production build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build Laravel Project
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, bcmath, pdo_mysql, xml, ctype, curl, json, openssl, tokenizer
+          coverage: none
+
+      - name: Authenticate Composer with GitHub
+        run: composer config --global github-oauth.github.com ${{ secrets.GH_PAT }}
+
+      - name: Install Composer dependencies
+        run: composer update --no-dev --optimize-autoloader
+
+      - name: Run Laravel optimize commands
+        run: |
+          php artisan config:cache
+          php artisan route:cache
+          php artisan view:cache
+
+      - name: Archive build
+        run: zip -r build.zip . -x ".git/*" "tests/*"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: laravel-build
+          path: build.zip
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "GITHUB_TOKEN environment variable is required" >&2
+  exit 1
+fi
+
+composer config --global github-oauth.github.com "$GITHUB_TOKEN"
+composer update --no-dev --optimize-autoloader
+php artisan config:cache
+php artisan route:cache
+php artisan view:cache
+zip -r build.zip . -x ".git/*" "tests/*" "node_modules/*"
+


### PR DESCRIPTION
## Summary
- add script to package Laravel app for production, requiring `GITHUB_TOKEN`
- authenticate Composer in CI using `GH_PAT` secret

## Testing
- `npm test` *(fails: command not found; apt repositories 403 when attempting install)*
- `php vendor/bin/phpunit` *(fails: Expected response status code [200] but received 404)*

------
https://chatgpt.com/codex/tasks/task_e_68bb77bdc5fc8332a03dea3fc05198fd