### PR TITLE
Implement tenancy scaffolding and domain middleware

### DIFF
--- a/app/Http/Middleware/InitializeTenancyByDomain.php
+++ b/app/Http/Middleware/InitializeTenancyByDomain.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Stancl\Tenancy\Middleware\InitializeTenancyByDomain as BaseInitializeTenancyByDomain;
+
+class InitializeTenancyByDomain extends BaseInitializeTenancyByDomain
+{
+    //
+}
+

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Stancl\Tenancy\Database\Models\Concerns\HasDatabase;
+use Stancl\Tenancy\Database\Models\Concerns\HasDomains;
+use Stancl\Tenancy\Database\Models\Tenant as BaseTenant;
+
+class Tenant extends BaseTenant
+{
+    use HasDatabase, HasDomains;
+}
+

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'tenant_id',
     ];
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use App\Http\Middleware\InitializeTenancyByDomain;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'tenancy' => InitializeTenancyByDomain::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -17,7 +17,6 @@ return [
      * Only relevant if you're using the domain or subdomain identification middleware.
      */
     'central_domains' => [
-        '127.0.0.1',
         'localhost',
     ],
 
@@ -163,12 +162,9 @@ return [
      * understand which ones you want to enable.
      */
     'features' => [
-        // Stancl\Tenancy\Features\UserImpersonation::class,
-        // Stancl\Tenancy\Features\TelescopeTags::class,
-        // Stancl\Tenancy\Features\UniversalRoutes::class,
-        // Stancl\Tenancy\Features\TenantConfig::class, // https://tenancyforlaravel.com/docs/v3/features/tenant-config
-        // Stancl\Tenancy\Features\CrossDomainRedirect::class, // https://tenancyforlaravel.com/docs/v3/features/cross-domain-redirect
-        // Stancl\Tenancy\Features\ViteBundler::class,
+        'database',
+        'redis',
+        'queue',
     ],
 
     /**

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id')->index();
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
@@ -25,10 +26,12 @@ return new class extends Migration
             $table->string('email')->primary();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
+            $table->foreignId('tenant_id')->index();
         });
 
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
+            $table->foreignId('tenant_id')->index();
             $table->foreignId('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();

--- a/database/migrations/central/2019_09_15_000010_create_tenants_table.php
+++ b/database/migrations/central/2019_09_15_000010_create_tenants_table.php
@@ -17,9 +17,9 @@ class CreateTenantsTable extends Migration
     {
         Schema::create('tenants', function (Blueprint $table) {
             $table->string('id')->primary();
-
-            // your custom columns may go here
-
+            $table->string('name');
+            $table->string('domain')->unique();
+            $table->string('plan_type')->nullable();
             $table->timestamps();
             $table->json('data')->nullable();
         });


### PR DESCRIPTION
## Summary
- add Tenant model using HasDatabase and HasDomains traits
- register tenancy middleware to init tenant by domain
- configure tenancy features and central domains
- index tenant_id on user-related tables

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68bf97409d208332b594ec03ffdfbfe7