### PR TITLE
Add tenant currency config and user locale handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /.zed
 /auth.json
 /node_modules
+Modules/*/node_modules
 /public/build
 /public/hot
 /public/storage

--- a/Modules/Pos/app/Models/MenuItem.php
+++ b/Modules/Pos/app/Models/MenuItem.php
@@ -3,6 +3,7 @@
 namespace Modules\Pos\Models;
 
 use App\Models\Tenant;
+use App\Support\CurrencyFormatter;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -32,5 +33,24 @@ class MenuItem extends Model implements Auditable
     public function orders(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
         return $this->belongsToMany(Order::class);
+    }
+
+    public function getFormattedPriceAttribute(): string
+    {
+        return CurrencyFormatter::format((float) $this->price);
+    }
+
+    public function toReportArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'price' => $this->formatted_price,
+        ];
+    }
+
+    public function toExportArray(): array
+    {
+        return $this->toReportArray();
     }
 }

--- a/Modules/Pos/app/Models/Order.php
+++ b/Modules/Pos/app/Models/Order.php
@@ -3,6 +3,7 @@
 namespace Modules\Pos\Models;
 
 use App\Models\Tenant;
+use App\Support\CurrencyFormatter;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -32,5 +33,24 @@ class Order extends Model implements Auditable
     public function menuItems(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
         return $this->belongsToMany(MenuItem::class);
+    }
+
+    public function getFormattedTotalAttribute(): string
+    {
+        return CurrencyFormatter::format((float) $this->total);
+    }
+
+    public function toReportArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'total' => $this->formatted_total,
+            'status' => $this->status,
+        ];
+    }
+
+    public function toExportArray(): array
+    {
+        return $this->toReportArray();
     }
 }

--- a/app/Http/Middleware/SetUserLocale.php
+++ b/app/Http/Middleware/SetUserLocale.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Carbon\Carbon;
+use Closure;
+use Illuminate\Http\Request;
+
+class SetUserLocale
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $locale = $request->user()->locale ?? config('app.locale');
+        app()->setLocale($locale);
+        Carbon::setLocale($locale);
+
+        return $next($request);
+    }
+}

--- a/app/Listeners/SetTenantCurrency.php
+++ b/app/Listeners/SetTenantCurrency.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Listeners;
+
+use Stancl\Tenancy\Events\TenancyInitialized;
+
+class SetTenantCurrency
+{
+    public function handle(TenancyInitialized $event): void
+    {
+        $currency = $event->tenant->get('currency') ?? config('app.currency');
+        config(['app.currency' => $currency]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,6 +30,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'locale',
         'tenant_id',
     ];
 

--- a/app/Providers/TenancyServiceProvider.php
+++ b/app/Providers/TenancyServiceProvider.php
@@ -70,6 +70,7 @@ class TenancyServiceProvider extends ServiceProvider
             Events\InitializingTenancy::class => [],
             Events\TenancyInitialized::class => [
                 Listeners\BootstrapTenancy::class,
+                \App\Listeners\SetTenantCurrency::class,
             ],
 
             Events\EndingTenancy::class => [],

--- a/app/Support/CurrencyFormatter.php
+++ b/app/Support/CurrencyFormatter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Support;
+
+use NumberFormatter;
+
+class CurrencyFormatter
+{
+    public static function format(float $amount): string
+    {
+        $currency = config('app.currency', 'USD');
+        $locale = app()->getLocale();
+        $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
+        return $formatter->formatCurrency($amount, $currency);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,6 +4,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use App\Http\Middleware\InitializeTenancyByDomain;
+use App\Http\Middleware\SetUserLocale;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -15,6 +16,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'tenancy' => InitializeTenancyByDomain::class,
         ]);
+        $middleware->append(SetUserLocale::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/app.php
+++ b/config/app.php
@@ -84,6 +84,8 @@ return [
 
     'faker_locale' => env('APP_FAKER_LOCALE', 'en_US'),
 
+    'currency' => env('APP_CURRENCY', 'USD'),
+
     /*
     |--------------------------------------------------------------------------
     | Encryption Key

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -31,6 +31,7 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'locale' => 'en',
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->string('locale', 5)->default('en');
             $table->rememberToken();
             $table->timestamps();
         });


### PR DESCRIPTION
## Summary
- add per-tenant currency config and formatter for price display, reports and exports
- localize dates and numbers by setting Carbon locale per user
- allow storing user locale on accounts

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bfb76ab2b88332a77b142df23f0c36