### PR TITLE
feat: localize notifications to recipient locale

### DIFF
--- a/app/Support/NotifiesWithLocale.php
+++ b/app/Support/NotifiesWithLocale.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Notifications\Notification;
+
+trait NotifiesWithLocale
+{
+    /**
+     * Send the given notification using the recipient's preferred locale.
+     */
+    public function notifyWithLocale(Notification $notification, ?string $locale = null): void
+    {
+        $locale = $locale ?? $this->locale ?? app()->getLocale();
+
+        $this->notify($notification->locale($locale));
+    }
+}

--- a/tests/Unit/NotifiesWithLocaleTest.php
+++ b/tests/Unit/NotifiesWithLocaleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Tests\TestCase;
+use App\Support\NotifiesWithLocale;
+
+class NotifiesWithLocaleTest extends TestCase
+{
+    public function test_notification_uses_recipient_locale(): void
+    {
+        $user = new class {
+            use Notifiable;
+            use NotifiesWithLocale;
+
+            public string $locale = 'fr';
+        };
+
+        $notification = new class extends Notification {
+            public function via($notifiable): array
+            {
+                return [];
+            }
+
+            public function getLocale(): ?string
+            {
+                return $this->locale;
+            }
+        };
+
+        $user->notifyWithLocale($notification);
+
+        $this->assertSame('fr', $notification->getLocale());
+    }
+}


### PR DESCRIPTION
## Summary
- add NotifiesWithLocale trait to send notifications using recipient's locale
- cover locale notification helper with unit test

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb96b9b50833287c4ee3865bf2128