### PR TITLE
feat: improve locale handling and rtl support

### DIFF
--- a/Modules/Jobs/app/Models/Job.php
+++ b/Modules/Jobs/app/Models/Job.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Modules\Jobs\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\HasTranslations;
+
+class Job extends Model
+{
+    use HasTranslations;
+
+    /**
+     * The attributes that are translatable.
+     *
+     * @var list<string>
+     */
+    protected array $translatable = ['description'];
+}

--- a/Modules/Jobs/composer.json
+++ b/Modules/Jobs/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "nwidart/jobs",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {}
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Jobs\\": "app/",
+            "Modules\\Jobs\\Database\\Factories\\": "database/factories/",
+            "Modules\\Jobs\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Jobs\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/Jobs/module.json
+++ b/Modules/Jobs/module.json
@@ -1,0 +1,9 @@
+{
+    "name": "Jobs",
+    "alias": "jobs",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [],
+    "files": []
+}

--- a/Modules/Marketplace/app/Models/Listing.php
+++ b/Modules/Marketplace/app/Models/Listing.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Modules\Marketplace\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Translatable\HasTranslations;
+
+class Listing extends Model
+{
+    use HasTranslations;
+
+    /**
+     * The attributes that are translatable.
+     *
+     * @var list<string>
+     */
+    protected array $translatable = ['description'];
+}

--- a/Modules/Marketplace/composer.json
+++ b/Modules/Marketplace/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "nwidart/marketplace",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {}
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Marketplace\\": "app/",
+            "Modules\\Marketplace\\Database\\Factories\\": "database/factories/",
+            "Modules\\Marketplace\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Marketplace\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/Marketplace/module.json
+++ b/Modules/Marketplace/module.json
@@ -1,0 +1,9 @@
+{
+    "name": "Marketplace",
+    "alias": "marketplace",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [],
+    "files": []
+}

--- a/app/Http/Middleware/SetUserLocale.php
+++ b/app/Http/Middleware/SetUserLocale.php
@@ -5,12 +5,19 @@ namespace App\Http\Middleware;
 use Carbon\Carbon;
 use Closure;
 use Illuminate\Http\Request;
+use function app;
+use function tenant;
 
 class SetUserLocale
 {
     public function handle(Request $request, Closure $next)
     {
-        $locale = $request->user()->locale ?? config('app.locale');
+        $tenantLocale = app()->has('tenant') ? app('tenant')->locale ?? null : tenant('locale');
+        $locale = $request->query('lang')
+            ?? session('locale')
+            ?? ($request->user()->locale ?? $tenantLocale ?? config('app.locale'));
+
+        session(['locale' => $locale]);
         app()->setLocale($locale);
         Carbon::setLocale($locale);
 

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use Stancl\Tenancy\Database\Models\Concerns\HasDatabase;
-use Stancl\Tenancy\Database\Models\Concerns\HasDomains;
+use Stancl\Tenancy\Database\Concerns\HasDatabase;
+use Stancl\Tenancy\Database\Concerns\HasDomains;
 use Stancl\Tenancy\Database\Models\Tenant as BaseTenant;
 use Spatie\Translatable\HasTranslations;
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,11 +8,12 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
 use Spatie\Translatable\HasTranslations;
+use App\Support\NotifiesWithLocale;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable, HasRoles, HasTranslations;
+    use HasFactory, Notifiable, HasRoles, HasTranslations, NotifiesWithLocale;
 
     /**
      * The attributes that are translatable.

--- a/resources/js/Components/FloorPlanDesigner.vue
+++ b/resources/js/Components/FloorPlanDesigner.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="floor-plan" :dir="isRtl ? 'rtl' : 'ltr'">
+    <div
+      v-for="table in tables"
+      :key="table.id"
+      class="table"
+      draggable="true"
+      @dragstart="dragStart(table)"
+      @dragover.prevent
+      @drop="drop(table)"
+    >
+      {{ table.name }}
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const { locale } = useI18n();
+const isRtl = computed(() => locale.value === 'ar');
+
+const tables = reactive([
+  { id: 1, name: 'A' },
+  { id: 2, name: 'B' },
+  { id: 3, name: 'C' },
+]);
+
+let dragged = null;
+
+function dragStart(table) {
+  dragged = table;
+}
+
+function drop(target) {
+  const from = tables.indexOf(dragged);
+  const to = tables.indexOf(target);
+  tables.splice(from, 1);
+  tables.splice(to, 0, dragged);
+}
+</script>
+
+<style scoped>
+.floor-plan {
+  display: flex;
+  gap: 1rem;
+}
+
+.table {
+  padding: 1rem;
+  background: #e5e7eb;
+  cursor: move;
+  user-select: none;
+}
+</style>

--- a/tests/Unit/SetUserLocaleTest.php
+++ b/tests/Unit/SetUserLocaleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Middleware\SetUserLocale;
+use App\Models\Tenant;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class SetUserLocaleTest extends TestCase
+{
+    public function test_defaults_to_tenant_locale(): void
+    {
+        $tenant = new Tenant(['id' => 't1', 'name' => ['en' => 'Tenant'], 'locale' => 'ar']);
+        app()->instance('tenant', $tenant);
+
+        $middleware = new SetUserLocale();
+        $request = Request::create('/', 'GET');
+        $session = app('session')->driver();
+        $request->setLaravelSession($session);
+        $session->start();
+
+        $middleware->handle($request, fn () => null);
+
+        $this->assertSame('ar', app()->getLocale());
+
+        app()->forgetInstance('tenant');
+    }
+
+    public function test_query_parameter_overrides_locale(): void
+    {
+        $tenant = new Tenant(['id' => 't1', 'name' => ['en' => 'Tenant'], 'locale' => 'ar']);
+        app()->instance('tenant', $tenant);
+
+        $middleware = new SetUserLocale();
+        $request = Request::create('/', 'GET', ['lang' => 'fr']);
+        $session = app('session')->driver();
+        $request->setLaravelSession($session);
+        $session->start();
+
+        $middleware->handle($request, fn () => null);
+
+        $this->assertSame('fr', app()->getLocale());
+        $this->assertSame('fr', session('locale'));
+
+        app()->forgetInstance('tenant');
+    }
+}


### PR DESCRIPTION
## Summary
- default locale to tenant with user override via query string
- send notifications using recipient locale
- add RTL-aware floor plan designer component
- enable translated descriptions for Marketplace listings and Jobs

## Testing
- `php artisan test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfbaa1e3648332abc68a4a062f5197