### PR TITLE
chore: bypass vite env check in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "build": "vite build",
         "dev": "vite",
-        "test": "vitest run"
+        "test": "LARAVEL_BYPASS_ENV_CHECK=1 vitest run"
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",


### PR DESCRIPTION
## Summary
- allow vitest to run in CI by bypassing Laravel Vite env check

## Testing
- `CI=true npm test`
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*

------
https://chatgpt.com/codex/tasks/task_e_68c024fe72cc83329469191430a02f90