### PR TITLE
Implement module scaffolding and status toggling

### DIFF
--- a/app/Console/Commands/MakeModule.php
+++ b/app/Console/Commands/MakeModule.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class MakeModule extends Command
+{
+    protected $signature = 'module:make {name}';
+
+    protected $description = 'Scaffold a new module directory structure';
+
+    public function handle(): int
+    {
+        $name = Str::studly($this->argument('name'));
+        $basePath = base_path("Modules/{$name}");
+
+        $directories = [
+            'Database/Migrations',
+            'Http/Controllers',
+            'Models',
+            'Resources',
+            'Routes',
+            'Services',
+            'Tests',
+        ];
+
+        foreach ($directories as $dir) {
+            File::ensureDirectoryExists("{$basePath}/{$dir}");
+        }
+
+        $routeFile = "{$basePath}/Routes/web.php";
+        if (!File::exists($routeFile)) {
+            File::put($routeFile, "<?php\n\nuse Illuminate\\Support\\Facades\\Route;\n\n// {$name} module routes\n");
+        }
+
+        $statusPath = base_path('modules_statuses.json');
+        $statuses = File::exists($statusPath) ? json_decode(File::get($statusPath), true) : [];
+        if (!array_key_exists($name, $statuses)) {
+            $statuses[$name] = false;
+            File::put($statusPath, json_encode($statuses, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        }
+
+        $this->info("Module {$name} scaffolded.");
+        return self::SUCCESS;
+    }
+}
+

--- a/app/Console/Commands/ToggleModule.php
+++ b/app/Console/Commands/ToggleModule.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
 use Nwidart\Modules\Facades\Module;
 
 class ToggleModule extends Command
@@ -12,15 +13,21 @@ class ToggleModule extends Command
     public function handle(): int
     {
         $module = $this->argument('name');
-        $status = $this->argument('status') === 'enable';
-        config(["{$module}_MODULE_ENABLED" => $status]);
-        if ($status) {
+        $enabled = $this->argument('status') === 'enable';
+
+        $statusPath = base_path('modules_statuses.json');
+        $statuses = File::exists($statusPath) ? json_decode(File::get($statusPath), true) : [];
+        $statuses[$module] = $enabled;
+        File::put($statusPath, json_encode($statuses, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        if ($enabled) {
             Module::enable($module);
-            $this->call('migrate', ['--path' => "Modules/{$module}/Database/Migrations"]);
+            $this->call('migrate', ['--path' => "Modules/{$module}/Database/Migrations", '--force' => true]);
         } else {
             Module::disable($module);
             $this->call('route:clear');
         }
-        return 0;
+
+        return self::SUCCESS;
     }
 }

--- a/app/Providers/ModuleServiceProvider.php
+++ b/app/Providers/ModuleServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
 use Nwidart\Modules\Facades\Module;
 
@@ -9,14 +10,15 @@ class ModuleServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        foreach (config('modules.modules', []) as $module => $settings) {
-            if (!Module::has($module)) {
-                continue;
-            }
-            if (!empty($settings['enabled'])) {
-                Module::enable($module);
+        $statusPath = base_path('modules_statuses.json');
+        $statuses = File::exists($statusPath) ? json_decode(File::get($statusPath), true) : [];
+
+        foreach (Module::all() as $module) {
+            $name = $module->getName();
+            if ($statuses[$name] ?? false) {
+                Module::enable($name);
             } else {
-                Module::disable($module);
+                Module::disable($name);
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `module:make` command to scaffold module directories and register status
- update `module:toggle` to persist enable/disable state and run migrations
- load module statuses from `modules_statuses.json` during boot

## Testing
- `composer install`
- `composer test` *(fails: file_get_contents(/workspace/cafeos/.env): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c02621975c833296ced17de67733d0