### PR TITLE
Add role and permission management

### DIFF
--- a/Modules/Core/config/permissions.php
+++ b/Modules/Core/config/permissions.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'permissions' => [
+        'core.manage_settings',
+    ],
+];

--- a/Modules/Crm/config/permissions.php
+++ b/Modules/Crm/config/permissions.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'permissions' => [
+        'crm.manage_customers',
+    ],
+];

--- a/Modules/Inventory/config/permissions.php
+++ b/Modules/Inventory/config/permissions.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'permissions' => [
+        'inventory.manage_products',
+    ],
+];

--- a/Modules/Jobs/config/permissions.php
+++ b/Modules/Jobs/config/permissions.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'permissions' => [
+        'jobs.manage_jobs',
+    ],
+];

--- a/Modules/Marketplace/config/permissions.php
+++ b/Modules/Marketplace/config/permissions.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'permissions' => [
+        'marketplace.manage_listings',
+    ],
+];

--- a/Modules/Pos/config/permissions.php
+++ b/Modules/Pos/config/permissions.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'permissions' => [
+        'pos.create_order',
+    ],
+];

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\UserResource\Pages;
+use App\Models\User;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Hash;
+
+class UserResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('name')->required(),
+            TextInput::make('email')->email()->required(),
+            TextInput::make('password')
+                ->password()
+                ->required(fn (string $context): bool => $context === 'create')
+                ->dehydrateStateUsing(fn ($state) => Hash::make($state))
+                ->visibleOn('create'),
+            Select::make('roles')
+                ->multiple()
+                ->relationship('roles', 'name')
+                ->preload(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name'),
+                TextColumn::make('email'),
+                TextColumn::make('roles.name')->label('Roles')->badge(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListUsers::route('/'),
+            'create' => Pages\CreateUser::route('/create'),
+            'edit' => Pages\EditUser::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/UserResource/Pages/CreateUser.php
+++ b/app/Filament/Resources/UserResource/Pages/CreateUser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUser extends CreateRecord
+{
+    protected static string $resource = UserResource::class;
+}

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditUser extends EditRecord
+{
+    protected static string $resource = UserResource::class;
+}

--- a/app/Filament/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Resources/UserResource/Pages/ListUsers.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUsers extends ListRecords
+{
+    protected static string $resource = UserResource::class;
+}

--- a/app/Listeners/SetPermissionsTeam.php
+++ b/app/Listeners/SetPermissionsTeam.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Listeners;
+
+use Spatie\Permission\PermissionRegistrar;
+
+class SetPermissionsTeam
+{
+    public function handle(): void
+    {
+        app(PermissionRegistrar::class)->setPermissionsTeamId(tenant('id'));
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -62,4 +62,9 @@ class User extends Authenticatable
     {
         static::addGlobalScope('tenant', fn ($q) => $q->where('tenant_id', tenant('id')));
     }
+
+    public function getPermissionsTeamId(): int|string|null
+    {
+        return $this->tenant_id;
+    }
 }

--- a/app/Providers/TenancyServiceProvider.php
+++ b/app/Providers/TenancyServiceProvider.php
@@ -27,7 +27,7 @@ class TenancyServiceProvider extends ServiceProvider
                 JobPipeline::make([
                     Jobs\CreateDatabase::class,
                     Jobs\MigrateDatabase::class,
-                    // Jobs\SeedDatabase::class,
+                    Jobs\SeedDatabase::class,
 
                     // Your own jobs to prepare the tenant.
                     // Provision API keys, create S3 buckets, anything you want!
@@ -71,6 +71,7 @@ class TenancyServiceProvider extends ServiceProvider
             Events\TenancyInitialized::class => [
                 Listeners\BootstrapTenancy::class,
                 \App\Listeners\SetTenantCurrency::class,
+                \App\Listeners\SetPermissionsTeam::class,
             ],
 
             Events\EndingTenancy::class => [],

--- a/config/permission.php
+++ b/config/permission.php
@@ -93,7 +93,7 @@ return [
          * foreign key is other than `team_id`.
          */
 
-        'team_foreign_key' => 'team_id',
+        'team_foreign_key' => 'tenant_id',
     ],
 
     /*
@@ -131,7 +131,7 @@ return [
      * (view the latest version of this package's migration file)
      */
 
-    'teams' => false,
+    'teams' => true,
 
     /*
      * The class to use to resolve the permissions team id

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call(RolesAndPermissionsSeeder::class);
 
         User::factory()->create([
             'name' => [
@@ -21,6 +21,7 @@ class DatabaseSeeder extends Seeder
                 'ar' => 'مستخدم تجريبي',
             ],
             'email' => 'test@example.com',
+            'tenant_id' => tenant('id'),
         ]);
     }
 }

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Nwidart\Modules\Facades\Module;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+class RolesAndPermissionsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        app(PermissionRegistrar::class)->setPermissionsTeamId(tenant('id'));
+
+        $allPermissions = [];
+        foreach (Module::all() as $module) {
+            $key = strtolower($module->getName()) . '.permissions';
+            $permissions = config($key, []);
+            foreach ($permissions as $permission) {
+                Permission::firstOrCreate([
+                    'name' => $permission,
+                    'guard_name' => 'web',
+                ]);
+            }
+            $allPermissions = array_merge($allPermissions, $permissions);
+        }
+
+        $manager = Role::firstOrCreate(['name' => 'Manager', 'guard_name' => 'web']);
+        $manager->givePermissionTo($allPermissions);
+
+        foreach (['Cashier', 'Waiter', 'Chef', 'Delivery'] as $role) {
+            Role::firstOrCreate(['name' => $role, 'guard_name' => 'web']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable team-based permissions scoped by tenant
- seed module permissions and roles (Manager, Cashier, Waiter, Chef, Delivery)
- add Filament user resource for assigning roles

## Testing
- `composer test` *(warnings: file_get_contents(.env): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0279385f88332a85a5cc700b702f8