### PR TITLE
feat(pos): add module component with i18n

### DIFF
--- a/resources/js/Modules/Pos/Enabled.vue
+++ b/resources/js/Modules/Pos/Enabled.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    {{ t('pos.enabled') }}
+  </div>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+</script>

--- a/resources/js/Pages/Pos/Dashboard.vue
+++ b/resources/js/Pages/Pos/Dashboard.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="p-4">
     <h1>{{ t('dashboard.title') }}</h1>
+    <PosEnabled />
     <div v-if="isInventoryEnabled" class="flex items-center gap-1">
       {{ t('dashboard.stock') }}: {{ stock }}
       <svg class="w-4 h-4 rtl:rotate-180" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
@@ -13,6 +14,7 @@
 <script setup>
 import { usePage } from '@inertiajs/vue3';
 import { useI18n } from 'vue-i18n';
+import PosEnabled from '../../Modules/Pos/Enabled.vue';
 
 const { t } = useI18n();
 const { props } = usePage();


### PR DESCRIPTION
## Summary
- add POS module-specific component using vue-i18n strings
- render POS enabled message in dashboard via new component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c02ea96e808332bf650efa5afc502e