### PR TITLE
Decouple modules with events and service contracts

### DIFF
--- a/Modules/Core/app/Contracts/OrderServiceInterface.php
+++ b/Modules/Core/app/Contracts/OrderServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Modules\Core\Contracts;
+
+use Modules\Pos\Models\Order;
+
+interface OrderServiceInterface
+{
+    public function make(array $attributes = []): Order;
+}

--- a/Modules/Inventory/app/Listeners/UpdateInventory.php
+++ b/Modules/Inventory/app/Listeners/UpdateInventory.php
@@ -2,7 +2,7 @@
 
 namespace Modules\Inventory\Listeners;
 
-use App\Events\OrderCreated;
+use Modules\Pos\Events\OrderCreated;
 use Illuminate\Support\Facades\Log;
 use Modules\Core\Contracts\InventoryServiceInterface;
 use Nwidart\Modules\Facades\Module as Modules;

--- a/Modules/Inventory/app/Providers/EventServiceProvider.php
+++ b/Modules/Inventory/app/Providers/EventServiceProvider.php
@@ -12,7 +12,7 @@ class EventServiceProvider extends ServiceProvider
      * @var array<string, array<int, string>>
      */
     protected $listen = [
-        \App\Events\OrderCreated::class => [
+        \Modules\Pos\Events\OrderCreated::class => [
             \Modules\Inventory\Listeners\UpdateInventory::class,
         ],
     ];

--- a/Modules/Pos/app/Events/OrderCreated.php
+++ b/Modules/Pos/app/Events/OrderCreated.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Events;
+namespace Modules\Pos\Events;
 
 use App\Models\Tenant;
 use Illuminate\Foundation\Events\Dispatchable;

--- a/Modules/Pos/app/Http/Controllers/OrderController.php
+++ b/Modules/Pos/app/Http/Controllers/OrderController.php
@@ -3,7 +3,7 @@
 namespace Modules\Pos\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use App\Events\OrderCreated;
+use Modules\Pos\Events\OrderCreated;
 use Illuminate\Http\Request;
 use Modules\Pos\Models\Order;
 

--- a/Modules/Pos/app/Providers/PosServiceProvider.php
+++ b/Modules/Pos/app/Providers/PosServiceProvider.php
@@ -7,6 +7,8 @@ use Illuminate\Support\ServiceProvider;
 use Nwidart\Modules\Traits\PathNamespace;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Modules\Core\Contracts\OrderServiceInterface;
+use Modules\Pos\Services\OrderService;
 
 class PosServiceProvider extends ServiceProvider
 {
@@ -36,6 +38,11 @@ class PosServiceProvider extends ServiceProvider
     {
         $this->app->register(EventServiceProvider::class);
         $this->app->register(RouteServiceProvider::class);
+
+        $this->app->bind(
+            OrderServiceInterface::class,
+            OrderService::class,
+        );
     }
 
     /**

--- a/Modules/Pos/app/Services/OrderService.php
+++ b/Modules/Pos/app/Services/OrderService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Modules\Pos\Services;
+
+use Modules\Core\Contracts\OrderServiceInterface;
+use Modules\Pos\Models\Order;
+
+class OrderService implements OrderServiceInterface
+{
+    public function make(array $attributes = []): Order
+    {
+        return new Order($attributes);
+    }
+}

--- a/tests/Feature/ModuleToggleTest.php
+++ b/tests/Feature/ModuleToggleTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
-use App\Events\OrderCreated;
+use Modules\Pos\Events\OrderCreated;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Modules\Inventory\Listeners\UpdateInventory;
-use Modules\Pos\Models\Order;
+use Modules\Core\Contracts\OrderServiceInterface;
 use Nwidart\Modules\Facades\Module as Modules;
 use Tests\TestCase;
 
@@ -28,7 +28,8 @@ class ModuleToggleTest extends TestCase
         Modules::disable('Inventory');
         Event::fake();
 
-        event(new OrderCreated(new Order()));
+        $order = app(OrderServiceInterface::class)->make();
+        event(new OrderCreated($order));
 
         Event::assertDispatched(OrderCreated::class);
         Event::assertNotDispatched(UpdateInventory::class);


### PR DESCRIPTION
## Summary
- Move `OrderCreated` event into POS module and register Inventory listener
- Add `OrderServiceInterface` and implementation for cross-module order handling
- Use service contract in tests to avoid direct module class usage

## Testing
- `composer dump-autoload --no-scripts`
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*

------
https://chatgpt.com/codex/tasks/task_e_68c032306bb8833288fa3c50e19f50f8