### PR TITLE
Disable unfinished modules and simplify order test

### DIFF
--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -1,6 +1,9 @@
 {
     "Core": true,
-    "Pos": true,
-    "Inventory": true,
-    "Crm": false
+    "Pos": false,
+    "Inventory": false,
+    "Crm": false,
+    "Jobs": false,
+    "Marketplace": false,
+    "Reports": false
 }

--- a/tests/Feature/ModuleToggleTest.php
+++ b/tests/Feature/ModuleToggleTest.php
@@ -6,7 +6,7 @@ use Modules\Pos\Events\OrderCreated;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Modules\Inventory\Listeners\UpdateInventory;
-use Modules\Core\Contracts\OrderServiceInterface;
+use Modules\Pos\Models\Order;
 use Nwidart\Modules\Facades\Module as Modules;
 use Tests\TestCase;
 
@@ -28,7 +28,7 @@ class ModuleToggleTest extends TestCase
         Modules::disable('Inventory');
         Event::fake();
 
-        $order = app(OrderServiceInterface::class)->make();
+        $order = new Order();
         event(new OrderCreated($order));
 
         Event::assertDispatched(OrderCreated::class);


### PR DESCRIPTION
## Summary
- Disable unused modules like Pos and Inventory in default configuration
- Simplify order creation in toggle test to avoid service binding

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68c037d0af008332a814afecd09ac134