### PR TITLE
Fix module scaffold placeholders and enhance tests

### DIFF
--- a/app/Console/Commands/MakeModule.php
+++ b/app/Console/Commands/MakeModule.php
@@ -41,14 +41,14 @@ class MakeModule extends Command
             $migrationStub = <<<'PHP'
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
     public function up(): void
     {
-        Schema::create('{$table}', function (Blueprint $table) {
+        Schema::create('{{table}}', function (Blueprint $table) {
             $table->id();
             $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
             $table->timestamps();
@@ -57,10 +57,11 @@ return new class extends Migration {
 
     public function down(): void
     {
-        Schema::dropIfExists('{$table}');
+        Schema::dropIfExists('{{table}}');
     }
 };
 PHP;
+            $migrationStub = str_replace('{{table}}', $table, $migrationStub);
             File::put($migrationPath, $migrationStub);
         }
 
@@ -69,15 +70,16 @@ PHP;
             $modelStub = <<<'PHP'
 <?php
 
-namespace Modules\\{$name}\\Models;
+namespace Modules\{{name}}\Models;
 
-use Illuminate\\Database\\Eloquent\\Model;
+use Illuminate\Database\Eloquent\Model;
 
-class {$name} extends Model
+class {{name}} extends Model
 {
     protected $fillable = ['tenant_id'];
 }
 PHP;
+            $modelStub = str_replace('{{name}}', $name, $modelStub);
             File::put($modelPath, $modelStub);
         }
 
@@ -96,11 +98,11 @@ PHP;
             $testStub = <<<'PHP'
 <?php
 
-namespace Modules\\{$name}\\Tests\\Feature;
+namespace Modules\{{name}}\Tests\Feature;
 
-use Tests\\TestCase;
+use Tests\TestCase;
 
-class {$name}ModuleTest extends TestCase
+class {{name}}ModuleTest extends TestCase
 {
     public function test_example(): void
     {
@@ -108,6 +110,7 @@ class {$name}ModuleTest extends TestCase
     }
 }
 PHP;
+            $testStub = str_replace('{{name}}', $name, $testStub);
             File::put($testPath, $testStub);
         }
 

--- a/docs/module-scaffolding.md
+++ b/docs/module-scaffolding.md
@@ -3,9 +3,10 @@
 The `module:make` Artisan command now scaffolds a module with key components ready for development:
 
 - **Database migration** including a `tenant_id` column for multi-tenancy.
-- **Eloquent model** matching the module name.
-- **Bilingual translation files** under `Resources/lang/en` and `Resources/lang/ar`.
+- **Eloquent model** with `tenant_id` in `$fillable`.
+- **Bilingual translation files** under `Resources/lang/en` and `Resources/lang/ar` with sample entries.
 - **Feature test** stub for isolated testing.
+- **`modules_statuses.json` entry** registering the module disabled by default.
 
 Example:
 

--- a/tests/Feature/MakeModuleCommandTest.php
+++ b/tests/Feature/MakeModuleCommandTest.php
@@ -16,16 +16,30 @@ class MakeModuleCommandTest extends TestCase
 
         $migrationFiles = glob("{$basePath}/Database/Migrations/*_create_blogs_table.php");
         $this->assertNotEmpty($migrationFiles);
-        $this->assertStringContainsString('tenant_id', File::get($migrationFiles[0]));
+        $migrationContent = File::get($migrationFiles[0]);
+        $this->assertStringContainsString('tenant_id', $migrationContent);
 
-        $this->assertFileExists("{$basePath}/Models/{$module}.php");
-        $this->assertFileExists("{$basePath}/Resources/lang/en/messages.php");
-        $this->assertFileExists("{$basePath}/Resources/lang/ar/messages.php");
-        $this->assertFileExists("{$basePath}/Tests/Feature/{$module}ModuleTest.php");
+        $modelPath = "{$basePath}/Models/{$module}.php";
+        $this->assertFileExists($modelPath);
+        $this->assertStringContainsString("protected \$fillable = ['tenant_id'];", File::get($modelPath));
 
-        File::deleteDirectory($basePath);
+        $langEn = "{$basePath}/Resources/lang/en/messages.php";
+        $langAr = "{$basePath}/Resources/lang/ar/messages.php";
+        $this->assertFileExists($langEn);
+        $this->assertFileExists($langAr);
+        $this->assertStringContainsString("'example' => 'Example'", File::get($langEn));
+        $this->assertStringContainsString("'example' => 'مثال'", File::get($langAr));
+
+        $testPath = "{$basePath}/Tests/Feature/{$module}ModuleTest.php";
+        $this->assertFileExists($testPath);
+        $this->assertStringContainsString('namespace Modules\\' . $module . '\\Tests\\Feature;', File::get($testPath));
+
         $statusPath = base_path('modules_statuses.json');
         $statuses = json_decode(File::get($statusPath), true);
+        $this->assertArrayHasKey($module, $statuses);
+        $this->assertFalse($statuses[$module]);
+
+        File::deleteDirectory($basePath);
         unset($statuses[$module]);
         File::put($statusPath, json_encode($statuses, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }


### PR DESCRIPTION
## Summary
- replace template tokens in migration, model, and test stubs during module scaffolding
- document all generated module components, including modules_statuses entry
- expand module scaffolding test to verify tenant support, translations, and status registration

## Testing
- `composer test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_68c04f53a73483328564b312584dcf17