### PR TITLE
feat(core): add multi-tenant core scaffolding

### DIFF
--- a/Modules/Core/app/Http/Controllers/Admin/TenantController.php
+++ b/Modules/Core/app/Http/Controllers/Admin/TenantController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Modules\Core\Http\Controllers\Admin;
+
+use App\Models\Tenant;
+use Illuminate\Contracts\View\View;
+
+class TenantController
+{
+    /**
+     * Display a listing of tenants.
+     */
+    public function index(): View
+    {
+        $tenants = Tenant::all();
+
+        return view('core::admin.tenants.index', compact('tenants'));
+    }
+}

--- a/Modules/Core/app/Http/Controllers/TenantSwitchController.php
+++ b/Modules/Core/app/Http/Controllers/TenantSwitchController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\Core\Http\Controllers;
+
+use App\Models\Tenant;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class TenantSwitchController
+{
+    /**
+     * Switch the current tenant context.
+     */
+    public function __invoke(Request $request): RedirectResponse
+    {
+        $tenant = Tenant::findOrFail($request->input('tenant_id'));
+        tenancy()->initialize($tenant);
+        session()->put('tenant_id', $tenant->id);
+
+        return redirect()->back();
+    }
+}

--- a/Modules/Core/app/Models/Permission.php
+++ b/Modules/Core/app/Models/Permission.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Modules\Core\Models;
+
+use Spatie\Permission\Models\Permission as SpatiePermission;
+
+class Permission extends SpatiePermission
+{
+    protected $fillable = [
+        'name',
+        'guard_name',
+        'tenant_id',
+    ];
+}

--- a/Modules/Core/app/Models/Role.php
+++ b/Modules/Core/app/Models/Role.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Modules\Core\Models;
+
+use Spatie\Permission\Models\Role as SpatieRole;
+
+class Role extends SpatieRole
+{
+    protected $fillable = [
+        'name',
+        'guard_name',
+        'tenant_id',
+    ];
+}

--- a/Modules/Core/app/Providers/CoreServiceProvider.php
+++ b/Modules/Core/app/Providers/CoreServiceProvider.php
@@ -4,6 +4,7 @@ namespace Modules\Core\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Modules\Core\Services\EventBus;
 use Nwidart\Modules\Traits\PathNamespace;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -36,6 +37,8 @@ class CoreServiceProvider extends ServiceProvider
     {
         $this->app->register(EventServiceProvider::class);
         $this->app->register(RouteServiceProvider::class);
+
+        $this->app->singleton(EventBus::class, fn ($app) => new EventBus($app['events']));
     }
 
     /**

--- a/Modules/Core/app/Services/EventBus.php
+++ b/Modules/Core/app/Services/EventBus.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Modules\Core\Services;
+
+use App\Models\Tenant;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class EventBus
+{
+    public function __construct(protected Dispatcher $dispatcher)
+    {
+    }
+
+    /**
+     * Dispatch an event within the current tenant context.
+     *
+     * @param  object|string  $event
+     * @param  array<int,mixed>  $payload
+     */
+    public function dispatch(object|string $event, array $payload = []): void
+    {
+        $this->dispatcher->dispatch($event, $payload);
+    }
+
+    /**
+     * Dispatch an event for a specific tenant.
+     *
+     * @param  Tenant  $tenant
+     * @param  object|string  $event
+     * @param  array<int,mixed>  $payload
+     */
+    public function dispatchToTenant(Tenant $tenant, object|string $event, array $payload = []): void
+    {
+        tenancy()->initialize($tenant);
+        $this->dispatch($event, $payload);
+        tenancy()->end();
+    }
+}

--- a/Modules/Core/database/migrations/2026_05_26_000000_create_tenants_table.php
+++ b/Modules/Core/database/migrations/2026_05_26_000000_create_tenants_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('tenants')) {
+            Schema::create('tenants', function (Blueprint $table) {
+                $table->id();
+                $table->string('name');
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tenants');
+    }
+};

--- a/Modules/Core/database/migrations/2026_05_26_000001_create_users_table.php
+++ b/Modules/Core/database/migrations/2026_05_26_000001_create_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('users')) {
+            Schema::create('users', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('tenant_id')->nullable()->constrained('tenants');
+                $table->string('name');
+                $table->string('email')->unique();
+                $table->string('password');
+                $table->rememberToken();
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/Modules/Core/database/migrations/2026_05_26_000002_create_roles_table.php
+++ b/Modules/Core/database/migrations/2026_05_26_000002_create_roles_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('roles')) {
+            Schema::create('roles', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('tenant_id')->nullable()->constrained('tenants');
+                $table->string('name');
+                $table->string('guard_name');
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/Modules/Core/database/migrations/2026_05_26_000003_create_permissions_table.php
+++ b/Modules/Core/database/migrations/2026_05_26_000003_create_permissions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('permissions')) {
+            Schema::create('permissions', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('tenant_id')->nullable()->constrained('tenants');
+                $table->string('name');
+                $table->string('guard_name');
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/Modules/Core/resources/views/admin/tenants/index.blade.php
+++ b/Modules/Core/resources/views/admin/tenants/index.blade.php
@@ -1,0 +1,8 @@
+<x-core::components.layouts.app>
+    <h1>{{ __('Tenants') }}</h1>
+    <ul>
+        @foreach($tenants as $tenant)
+            <li>{{ $tenant->name }}</li>
+        @endforeach
+    </ul>
+</x-core::components.layouts.app>

--- a/Modules/Core/resources/views/components/layouts/app.blade.php
+++ b/Modules/Core/resources/views/components/layouts/app.blade.php
@@ -1,0 +1,4 @@
+<x-core::components.layouts.master>
+    <x-core::tenant-switcher />
+    {{ $slot }}
+</x-core::components.layouts.master>

--- a/Modules/Core/resources/views/components/tenant-switcher.blade.php
+++ b/Modules/Core/resources/views/components/tenant-switcher.blade.php
@@ -1,0 +1,8 @@
+<form method="POST" action="{{ route('tenant.switch') }}">
+    @csrf
+    <select name="tenant_id" onchange="this.form.submit()">
+        @foreach(\App\Models\Tenant::all() as $tenant)
+            <option value="{{ $tenant->id }}" @selected(tenant('id') === $tenant->id)>{{ $tenant->name }}</option>
+        @endforeach
+    </select>
+</form>

--- a/Modules/Core/routes/web.php
+++ b/Modules/Core/routes/web.php
@@ -1,8 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Modules\Core\Http\Controllers\Admin\TenantController;
 use Modules\Core\Http\Controllers\CoreController;
+use Modules\Core\Http\Controllers\TenantSwitchController;
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('cores', CoreController::class)->names('core');
+    Route::post('tenant/switch', TenantSwitchController::class)->name('tenant.switch');
+    Route::get('admin/tenants', [TenantController::class, 'index'])->name('admin.tenants.index');
 });

--- a/config/permission.php
+++ b/config/permission.php
@@ -13,7 +13,7 @@ return [
          * `Spatie\Permission\Contracts\Permission` contract.
          */
 
-        'permission' => Spatie\Permission\Models\Permission::class,
+        'permission' => Modules\Core\Models\Permission::class,
 
         /*
          * When using the "HasRoles" trait from this package, we need to know which
@@ -24,7 +24,7 @@ return [
          * `Spatie\Permission\Contracts\Role` contract.
          */
 
-        'role' => Spatie\Permission\Models\Role::class,
+        'role' => Modules\Core\Models\Role::class,
 
     ],
 


### PR DESCRIPTION
## Summary
- wire up custom Role/Permission models for tenancy
- introduce EventBus and bind via Core service provider
- add tenant switcher UI, admin tenant index, and supporting routes/controllers
- scaffold migrations for tenants, users, roles, permissions

## Testing
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c051d0b5e483329c9b5c3126eb0fb5