### PR TITLE
feat(kds): add kitchen display module

### DIFF
--- a/Modules/Kds/app/Listeners/CreateKitchenTicket.php
+++ b/Modules/Kds/app/Listeners/CreateKitchenTicket.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Modules\Kds\Listeners;
+
+use Modules\Pos\Events\OrderCreated;
+use Modules\Kds\Models\KitchenTicket;
+
+class CreateKitchenTicket
+{
+    public function handle(OrderCreated $event): void
+    {
+        KitchenTicket::create([
+            'order_id' => $event->order->id,
+            'status' => 'pending',
+            'approved' => true,
+        ]);
+    }
+}

--- a/Modules/Kds/app/Models/KitchenStation.php
+++ b/Modules/Kds/app/Models/KitchenStation.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Modules\Kds\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class KitchenStation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/Modules/Kds/app/Models/KitchenTicket.php
+++ b/Modules/Kds/app/Models/KitchenTicket.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Modules\Kds\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class KitchenTicket extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'station_id',
+        'status',
+        'approved',
+    ];
+
+    public function order()
+    {
+        return $this->belongsTo(\Modules\Pos\Models\Order::class);
+    }
+
+    public function station()
+    {
+        return $this->belongsTo(KitchenStation::class);
+    }
+
+    public function getStatusColorAttribute(): string
+    {
+        return match ($this->status) {
+            'pending' => 'yellow',
+            'cooking' => 'orange',
+            'ready' => 'green',
+            default => 'gray',
+        };
+    }
+}

--- a/Modules/Kds/app/Providers/EventServiceProvider.php
+++ b/Modules/Kds/app/Providers/EventServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Modules\Kds\Providers;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Modules\Pos\Events\OrderCreated;
+use Modules\Kds\Listeners\CreateKitchenTicket;
+
+class EventServiceProvider extends ServiceProvider
+{
+    protected $listen = [
+        OrderCreated::class => [
+            CreateKitchenTicket::class,
+        ],
+    ];
+}

--- a/Modules/Kds/app/Providers/KdsServiceProvider.php
+++ b/Modules/Kds/app/Providers/KdsServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Modules\Kds\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class KdsServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->register(EventServiceProvider::class);
+        $this->app->register(RouteServiceProvider::class);
+    }
+
+    public function boot(): void
+    {
+        $this->mergeConfigFrom(module_path('Kds', 'config/config.php'), 'kds');
+        $this->loadMigrationsFrom(module_path('Kds', 'database/migrations'));
+    }
+}

--- a/Modules/Kds/app/Providers/RouteServiceProvider.php
+++ b/Modules/Kds/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Modules\Kds\Providers;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->routes(function () {
+            Route::middleware('api')
+                ->prefix('api/kds')
+                ->group(module_path('Kds', 'routes/api.php'));
+        });
+    }
+}

--- a/Modules/Kds/composer.json
+++ b/Modules/Kds/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "nwidart/kds",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {
+
+            }
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Kds\\": "app/",
+            "Modules\\Kds\\Database\\Factories\\": "database/factories/",
+            "Modules\\Kds\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Kds\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/Kds/config/config.php
+++ b/Modules/Kds/config/config.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'name' => 'Kds',
+
+    // Default kitchen stations. Admins can modify this list.
+    'stations' => [
+        'General',
+    ],
+];

--- a/Modules/Kds/database/migrations/2025_09_09_100000_create_kitchen_stations_table.php
+++ b/Modules/Kds/database/migrations/2025_09_09_100000_create_kitchen_stations_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('kitchen_stations', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('kitchen_stations');
+    }
+};

--- a/Modules/Kds/database/migrations/2025_09_09_100100_create_kitchen_tickets_table.php
+++ b/Modules/Kds/database/migrations/2025_09_09_100100_create_kitchen_tickets_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('kitchen_tickets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained('orders');
+            $table->foreignId('station_id')->nullable()->constrained('kitchen_stations');
+            $table->enum('status', ['pending', 'cooking', 'ready'])->default('pending');
+            $table->boolean('approved')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('kitchen_tickets');
+    }
+};

--- a/Modules/Kds/module.json
+++ b/Modules/Kds/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "Kds",
+    "alias": "kds",
+    "description": "Kitchen Display System",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\Kds\\Providers\\KdsServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/Kds/routes/api.php
+++ b/Modules/Kds/routes/api.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Kds\Models\KitchenTicket;
+
+Route::get('tickets', function () {
+    return KitchenTicket::where('approved', true)
+        ->get()
+        ->map(fn (KitchenTicket $ticket) => [
+            'id' => $ticket->id,
+            'order_id' => $ticket->order_id,
+            'status' => $ticket->status,
+            'status_color' => $ticket->status_color,
+        ]);
+});

--- a/Modules/Kds/tests/Unit/KitchenTicketTest.php
+++ b/Modules/Kds/tests/Unit/KitchenTicketTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Modules\Kds\Tests\Unit;
+
+use Modules\Kds\Models\KitchenTicket;
+use Tests\TestCase;
+
+class KitchenTicketTest extends TestCase
+{
+    public function test_status_color_mapping()
+    {
+        $ticket = new KitchenTicket(['status' => 'cooking']);
+        $this->assertEquals('orange', $ticket->status_color);
+    }
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -6,5 +6,6 @@
     "Jobs": false,
     "Marketplace": false,
     "Reports": false,
-    "SuperAdmin": false
+    "SuperAdmin": false,
+    "Kds": false
 }


### PR DESCRIPTION
## Summary
- scaffold KDS module with migrations and configuration
- create kitchen ticket model with status colors and API endpoint
- integrate POS order events to generate kitchen tickets

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c05746d0e48332a51ef760c582f2c8