### PR TITLE
feat(crm): scaffold customer profile and order history services

### DIFF
--- a/Modules/Crm/app/Contracts/CustomerProfileServiceInterface.php
+++ b/Modules/Crm/app/Contracts/CustomerProfileServiceInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\Crm\Contracts;
+
+interface CustomerProfileServiceInterface
+{
+    /**
+     * Retrieve customer's profile information including loyalty points.
+     */
+    public function getProfile(int|string $customerId): array;
+}

--- a/Modules/Crm/app/Contracts/OrderHistoryServiceInterface.php
+++ b/Modules/Crm/app/Contracts/OrderHistoryServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Crm\Contracts;
+
+use Illuminate\Support\Collection;
+
+interface OrderHistoryServiceInterface
+{
+    /**
+     * Get the order history for the given customer.
+     */
+    public function getOrders(int|string $customerId): Collection;
+}

--- a/Modules/Crm/app/Providers/CrmServiceProvider.php
+++ b/Modules/Crm/app/Providers/CrmServiceProvider.php
@@ -4,6 +4,10 @@ namespace Modules\Crm\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Modules\Crm\Contracts\CustomerProfileServiceInterface;
+use Modules\Crm\Contracts\OrderHistoryServiceInterface;
+use Modules\Crm\Services\CustomerProfileService;
+use Modules\Crm\Services\OrderHistoryService;
 use Nwidart\Modules\Traits\PathNamespace;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -36,6 +40,9 @@ class CrmServiceProvider extends ServiceProvider
     {
         $this->app->register(EventServiceProvider::class);
         $this->app->register(RouteServiceProvider::class);
+
+        $this->app->bind(CustomerProfileServiceInterface::class, CustomerProfileService::class);
+        $this->app->bind(OrderHistoryServiceInterface::class, OrderHistoryService::class);
     }
 
     /**

--- a/Modules/Crm/app/Services/CustomerProfileService.php
+++ b/Modules/Crm/app/Services/CustomerProfileService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Modules\Crm\Services;
+
+use Modules\Crm\Contracts\CustomerProfileServiceInterface;
+use Modules\Membership\Contracts\LoyaltyServiceInterface;
+
+class CustomerProfileService implements CustomerProfileServiceInterface
+{
+    public function __construct(private LoyaltyServiceInterface $loyalty)
+    {
+    }
+
+    public function getProfile(int|string $customerId): array
+    {
+        return [
+            'id' => $customerId,
+            'points' => $this->loyalty->getPoints($customerId),
+        ];
+    }
+}

--- a/Modules/Crm/app/Services/OrderHistoryService.php
+++ b/Modules/Crm/app/Services/OrderHistoryService.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Modules\Crm\Services;
+
+use Illuminate\Support\Collection;
+use Modules\Crm\Contracts\OrderHistoryServiceInterface;
+use Modules\Pos\Models\Order;
+
+class OrderHistoryService implements OrderHistoryServiceInterface
+{
+    public function getOrders(int|string $customerId): Collection
+    {
+        return Order::where('customer_id', $customerId)->get();
+    }
+}

--- a/Modules/Crm/tests/Unit/CustomerProfileServiceTest.php
+++ b/Modules/Crm/tests/Unit/CustomerProfileServiceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Crm\Tests\Unit;
+
+use Modules\Crm\Contracts\CustomerProfileServiceInterface;
+use Modules\Crm\Providers\CrmServiceProvider;
+use Modules\Membership\Contracts\LoyaltyServiceInterface;
+use Tests\TestCase;
+
+class CustomerProfileServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->register(CrmServiceProvider::class);
+    }
+
+    public function test_it_returns_profile_with_points(): void
+    {
+        $loyalty = \Mockery::mock(LoyaltyServiceInterface::class);
+        $loyalty->shouldReceive('getPoints')->once()->with(1)->andReturn(10);
+        $this->app->instance(LoyaltyServiceInterface::class, $loyalty);
+
+        $service = $this->app->make(CustomerProfileServiceInterface::class);
+        $profile = $service->getProfile(1);
+
+        $this->assertSame(10, $profile['points']);
+    }
+}

--- a/Modules/Crm/tests/Unit/OrderHistoryServiceTest.php
+++ b/Modules/Crm/tests/Unit/OrderHistoryServiceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\Crm\Tests\Unit;
+
+use Modules\Crm\Contracts\OrderHistoryServiceInterface;
+use Modules\Crm\Providers\CrmServiceProvider;
+use Tests\TestCase;
+
+class OrderHistoryServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->register(CrmServiceProvider::class);
+    }
+
+    public function test_service_resolves(): void
+    {
+        $service = $this->app->make(OrderHistoryServiceInterface::class);
+        $this->assertNotNull($service);
+    }
+}

--- a/Modules/Membership/app/Contracts/LoyaltyServiceInterface.php
+++ b/Modules/Membership/app/Contracts/LoyaltyServiceInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Modules\Membership\Contracts;
+
+interface LoyaltyServiceInterface
+{
+    public function getPoints(int|string $customerId): int;
+}

--- a/Modules/Membership/app/Providers/MembershipServiceProvider.php
+++ b/Modules/Membership/app/Providers/MembershipServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Modules\Membership\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Modules\Membership\Contracts\LoyaltyServiceInterface;
+use Modules\Membership\Services\LoyaltyService;
 
 class MembershipServiceProvider extends ServiceProvider
 {
@@ -17,7 +19,7 @@ class MembershipServiceProvider extends ServiceProvider
 
     public function register(): void
     {
-        //
+        $this->app->bind(LoyaltyServiceInterface::class, LoyaltyService::class);
     }
 
     protected function registerConfig(): void

--- a/Modules/Membership/app/Services/LoyaltyService.php
+++ b/Modules/Membership/app/Services/LoyaltyService.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Membership\Services;
+
+use Modules\Membership\Contracts\LoyaltyServiceInterface;
+
+class LoyaltyService implements LoyaltyServiceInterface
+{
+    public function getPoints(int|string $customerId): int
+    {
+        return 0;
+    }
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -1,8 +1,8 @@
 {
     "Core": true,
-    "Pos": false,
+    "Pos": true,
     "Inventory": false,
-    "Crm": false,
+    "Crm": true,
     "Jobs": false,
     "Marketplace": false,
     "Reports": false,
@@ -11,5 +11,5 @@
     "FloorPlanDesigner": false,
     "Procurement": false,
     "Billing": false,
-    "Membership": false
+    "Membership": true
 }

--- a/tests/Feature/ModuleAccessTest.php
+++ b/tests/Feature/ModuleAccessTest.php
@@ -26,9 +26,7 @@ class ModuleAccessTest extends TestCase
 
     public function test_disabled_modules_do_not_register_routes(): void
     {
-        $this->assertFalse(Route::has('crm.index'));
         $this->assertFalse(Route::has('inventory.index'));
-        $this->assertFalse(Route::has('pos.index'));
     }
 
     public static function activeModuleProvider(): array


### PR DESCRIPTION
## Summary
- enable CRM, POS, and Membership modules
- add customer profile and order history service interfaces and implementations
- expose loyalty service in membership module and bind CRM services
- adjust module access tests and add unit tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c064c879148332af47ce1810899989