### PR TITLE
feat: add loyalty module with rewards

### DIFF
--- a/Modules/Crm/app/Services/CustomerProfileService.php
+++ b/Modules/Crm/app/Services/CustomerProfileService.php
@@ -3,7 +3,7 @@
 namespace Modules\Crm\Services;
 
 use Modules\Crm\Contracts\CustomerProfileServiceInterface;
-use Modules\Membership\Contracts\LoyaltyServiceInterface;
+use Modules\Loyalty\Contracts\LoyaltyServiceInterface;
 
 class CustomerProfileService implements CustomerProfileServiceInterface
 {

--- a/Modules/Crm/tests/Unit/CustomerProfileServiceTest.php
+++ b/Modules/Crm/tests/Unit/CustomerProfileServiceTest.php
@@ -4,7 +4,7 @@ namespace Modules\Crm\Tests\Unit;
 
 use Modules\Crm\Contracts\CustomerProfileServiceInterface;
 use Modules\Crm\Providers\CrmServiceProvider;
-use Modules\Membership\Contracts\LoyaltyServiceInterface;
+use Modules\Loyalty\Contracts\LoyaltyServiceInterface;
 use Tests\TestCase;
 
 class CustomerProfileServiceTest extends TestCase

--- a/Modules/Loyalty/app/Contracts/LoyaltyServiceInterface.php
+++ b/Modules/Loyalty/app/Contracts/LoyaltyServiceInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Modules\Loyalty\Contracts;
+
+use Modules\Loyalty\Models\Coupon;
+
+interface LoyaltyServiceInterface
+{
+    /**
+     * Accrue loyalty points for a customer.
+     */
+    public function accruePoints(int|string $customerId, int $points, ?int $tenantId = null): void;
+
+    /**
+     * Redeem loyalty points for a customer.
+     */
+    public function redeemPoints(int|string $customerId, int $points): bool;
+
+    /**
+     * Get current loyalty points for a customer.
+     */
+    public function getPoints(int|string $customerId): int;
+
+    /**
+     * Issue a coupon/voucher to a customer.
+     */
+    public function issueCoupon(int|string $customerId, int $value): Coupon;
+
+    /**
+     * Redeem a coupon by code.
+     */
+    public function redeemCoupon(string $code): bool;
+}

--- a/Modules/Loyalty/app/Models/Coupon.php
+++ b/Modules/Loyalty/app/Models/Coupon.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Modules\Loyalty\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Coupon extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'customer_id',
+        'tenant_id',
+        'code',
+        'value',
+        'redeemed_at',
+    ];
+
+    protected $casts = [
+        'redeemed_at' => 'datetime',
+    ];
+}

--- a/Modules/Loyalty/app/Models/LoyaltyPoint.php
+++ b/Modules/Loyalty/app/Models/LoyaltyPoint.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Modules\Loyalty\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LoyaltyPoint extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'customer_id',
+        'tenant_id',
+        'points',
+    ];
+}

--- a/Modules/Loyalty/app/Providers/LoyaltyServiceProvider.php
+++ b/Modules/Loyalty/app/Providers/LoyaltyServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Modules\Loyalty\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Modules\Loyalty\Contracts\LoyaltyServiceInterface;
+use Modules\Loyalty\Services\LoyaltyService;
+
+class LoyaltyServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(module_path('Loyalty', 'database/migrations'));
+    }
+
+    public function register(): void
+    {
+        $this->app->bind(LoyaltyServiceInterface::class, LoyaltyService::class);
+    }
+}

--- a/Modules/Loyalty/app/Services/LoyaltyService.php
+++ b/Modules/Loyalty/app/Services/LoyaltyService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Modules\Loyalty\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Modules\Loyalty\Contracts\LoyaltyServiceInterface;
+use Modules\Loyalty\Models\Coupon;
+use Modules\Loyalty\Models\LoyaltyPoint;
+
+class LoyaltyService implements LoyaltyServiceInterface
+{
+    public function accruePoints(int|string $customerId, int $points, ?int $tenantId = null): void
+    {
+        LoyaltyPoint::create([
+            'customer_id' => $customerId,
+            'tenant_id' => $tenantId,
+            'points' => $points,
+        ]);
+    }
+
+    public function redeemPoints(int|string $customerId, int $points): bool
+    {
+        return DB::transaction(function () use ($customerId, $points) {
+            $current = $this->getPoints($customerId);
+            if ($current < $points) {
+                return false;
+            }
+            LoyaltyPoint::create([
+                'customer_id' => $customerId,
+                'points' => -$points,
+            ]);
+            return true;
+        });
+    }
+
+    public function getPoints(int|string $customerId): int
+    {
+        return (int) LoyaltyPoint::where('customer_id', $customerId)->sum('points');
+    }
+
+    public function issueCoupon(int|string $customerId, int $value): Coupon
+    {
+        return Coupon::create([
+            'customer_id' => $customerId,
+            'code' => Str::uuid()->toString(),
+            'value' => $value,
+        ]);
+    }
+
+    public function redeemCoupon(string $code): bool
+    {
+        $coupon = Coupon::where('code', $code)->whereNull('redeemed_at')->first();
+        if (! $coupon) {
+            return false;
+        }
+        $coupon->update(['redeemed_at' => now()]);
+        return true;
+    }
+}

--- a/Modules/Loyalty/composer.json
+++ b/Modules/Loyalty/composer.json
@@ -15,14 +15,14 @@
     },
     "autoload": {
         "psr-4": {
-            "Modules\\\\Loyalty\\\\": "app/",
-            "Modules\\\\Loyalty\\\\Database\\\\Factories\\\\": "database/factories/",
-            "Modules\\\\Loyalty\\\\Database\\\\Seeders\\\\": "database/seeders/"
+            "Modules\\Loyalty\\": "app/",
+            "Modules\\Loyalty\\Database\\Factories\\": "database/factories/",
+            "Modules\\Loyalty\\Database\\Seeders\\": "database/seeders/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Modules\\\\Loyalty\\\\Tests\\\\": "tests/"
+            "Modules\\Loyalty\\Tests\\": "tests/"
         }
     }
 }

--- a/Modules/Loyalty/composer.json
+++ b/Modules/Loyalty/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "nwidart/loyalty",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {}
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\\\Loyalty\\\\": "app/",
+            "Modules\\\\Loyalty\\\\Database\\\\Factories\\\\": "database/factories/",
+            "Modules\\\\Loyalty\\\\Database\\\\Seeders\\\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\\\Loyalty\\\\Tests\\\\": "tests/"
+        }
+    }
+}

--- a/Modules/Loyalty/database/migrations/2024_01_01_000000_create_loyalty_points_table.php
+++ b/Modules/Loyalty/database/migrations/2024_01_01_000000_create_loyalty_points_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('loyalty_points', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->nullable()->constrained('tenants');
+            $table->foreignId('customer_id')->constrained('users');
+            $table->integer('points');
+            $table->timestamps();
+            $table->index('tenant_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('loyalty_points');
+    }
+};

--- a/Modules/Loyalty/database/migrations/2024_01_01_000001_create_coupons_table.php
+++ b/Modules/Loyalty/database/migrations/2024_01_01_000001_create_coupons_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('coupons', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->nullable()->constrained('tenants');
+            $table->foreignId('customer_id')->constrained('users');
+            $table->string('code')->unique();
+            $table->integer('value');
+            $table->timestamp('redeemed_at')->nullable();
+            $table->timestamps();
+            $table->index('tenant_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('coupons');
+    }
+};

--- a/Modules/Loyalty/module.json
+++ b/Modules/Loyalty/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "Loyalty",
+    "alias": "loyalty",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\Loyalty\\Providers\\LoyaltyServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/Pos/app/Listeners/AwardLoyaltyPoints.php
+++ b/Modules/Pos/app/Listeners/AwardLoyaltyPoints.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\Pos\Listeners;
+
+use Modules\Loyalty\Contracts\LoyaltyServiceInterface;
+use Modules\Pos\Events\OrderCreated;
+
+class AwardLoyaltyPoints
+{
+    public function __construct(private LoyaltyServiceInterface $loyalty)
+    {
+    }
+
+    public function handle(OrderCreated $event): void
+    {
+        $customerId = $event->order->customer_id ?? null;
+        if ($customerId) {
+            $points = (int) $event->order->total;
+            $this->loyalty->accruePoints($customerId, $points, $event->tenant?->id);
+        }
+    }
+}

--- a/Modules/Pos/app/Providers/EventServiceProvider.php
+++ b/Modules/Pos/app/Providers/EventServiceProvider.php
@@ -4,7 +4,9 @@ namespace Modules\Pos\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Modules\FloorPlanDesigner\Events\FloorLayoutUpdated;
+use Modules\Pos\Events\OrderCreated;
 use Modules\Pos\Listeners\SyncFloorLayout;
+use Modules\Pos\Listeners\AwardLoyaltyPoints;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -16,6 +18,9 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         FloorLayoutUpdated::class => [
             SyncFloorLayout::class,
+        ],
+        OrderCreated::class => [
+            AwardLoyaltyPoints::class,
         ],
     ];
 

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -11,5 +11,6 @@
     "FloorPlanDesigner": false,
     "Procurement": false,
     "Billing": false,
-    "Membership": true
+    "Membership": true,
+    "Loyalty": true
 }


### PR DESCRIPTION
## Summary
- scaffold Loyalty module with points accrual/redemption and coupon issuance
- integrate Loyalty with CRM profiles and POS orders
- add migrations for loyalty_points and coupons

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*

------
https://chatgpt.com/codex/tasks/task_e_68c066ad4e208332bf1a2c67ea337719