### PR TITLE
feat: scaffold notifications module

### DIFF
--- a/Modules/Billing/app/Events/UnpaidBillAlert.php
+++ b/Modules/Billing/app/Events/UnpaidBillAlert.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Modules\Billing\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Modules\Pos\Models\Order;
+
+class UnpaidBillAlert
+{
+    use Dispatchable;
+
+    public function __construct(public Order $order)
+    {
+    }
+}

--- a/Modules/Membership/app/Events/SubscriptionExpiring.php
+++ b/Modules/Membership/app/Events/SubscriptionExpiring.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Modules\Membership\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Support\Carbon;
+
+class SubscriptionExpiring
+{
+    use Dispatchable;
+
+    public function __construct(public int|string $customerId, public Carbon $expiresAt)
+    {
+    }
+}

--- a/Modules/Membership/app/Services/LoyaltyService.php
+++ b/Modules/Membership/app/Services/LoyaltyService.php
@@ -3,11 +3,20 @@
 namespace Modules\Membership\Services;
 
 use Modules\Membership\Contracts\LoyaltyServiceInterface;
+use Modules\Membership\Events\SubscriptionExpiring;
+use Illuminate\Support\Carbon;
 
 class LoyaltyService implements LoyaltyServiceInterface
 {
     public function getPoints(int|string $customerId): int
     {
         return 0;
+    }
+
+    public function checkSubscriptionExpiry(int|string $customerId, Carbon $expiresAt): void
+    {
+        if ($expiresAt->diffInDays(now()) <= 7) {
+            event(new SubscriptionExpiring($customerId, $expiresAt));
+        }
     }
 }

--- a/Modules/Notifications/app/Channels/EmailChannel.php
+++ b/Modules/Notifications/app/Channels/EmailChannel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Notifications\Channels;
+
+use Illuminate\Support\Facades\Log;
+
+class EmailChannel
+{
+    public function send(string $message): void
+    {
+        Log::info('Email notification: '.$message);
+    }
+}

--- a/Modules/Notifications/app/Channels/InAppChannel.php
+++ b/Modules/Notifications/app/Channels/InAppChannel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Notifications\Channels;
+
+use Illuminate\Support\Facades\Log;
+
+class InAppChannel
+{
+    public function send(string $message): void
+    {
+        Log::info('In-app notification: '.$message);
+    }
+}

--- a/Modules/Notifications/app/Channels/PushChannel.php
+++ b/Modules/Notifications/app/Channels/PushChannel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Notifications\Channels;
+
+use Illuminate\Support\Facades\Log;
+
+class PushChannel
+{
+    public function send(string $message): void
+    {
+        Log::info('Push notification: '.$message);
+    }
+}

--- a/Modules/Notifications/app/Channels/SmsChannel.php
+++ b/Modules/Notifications/app/Channels/SmsChannel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Notifications\Channels;
+
+use Illuminate\Support\Facades\Log;
+
+class SmsChannel
+{
+    public function send(string $message): void
+    {
+        Log::info('SMS notification: '.$message);
+    }
+}

--- a/Modules/Notifications/app/Listeners/SendNotification.php
+++ b/Modules/Notifications/app/Listeners/SendNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Modules\Notifications\Listeners;
+
+use Modules\Notifications\Services\NotificationService;
+use Modules\Inventory\Events\LowStockAlert;
+use Modules\Billing\Events\UnpaidBillAlert;
+use Modules\Pos\Events\TableOpened;
+use Modules\Membership\Events\SubscriptionExpiring;
+
+class SendNotification
+{
+    public function __construct(private NotificationService $notifications)
+    {
+    }
+
+    public function handle(object $event): void
+    {
+        $message = match (true) {
+            $event instanceof LowStockAlert => 'Low stock for '.$event->item->name,
+            $event instanceof UnpaidBillAlert => 'Unpaid bill for order #'.$event->order->id,
+            $event instanceof TableOpened => 'Table opened for order #'.$event->order->id,
+            $event instanceof SubscriptionExpiring => 'Subscription for '.$event->customerId.' expires on '.$event->expiresAt->toDateString(),
+            default => 'Notification',
+        };
+
+        $channels = config('notifications.channels', ['in-app']);
+        $this->notifications->send($message, $channels);
+    }
+}

--- a/Modules/Notifications/app/Providers/EventServiceProvider.php
+++ b/Modules/Notifications/app/Providers/EventServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Modules\Notifications\Providers;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Modules\Inventory\Events\LowStockAlert;
+use Modules\Billing\Events\UnpaidBillAlert;
+use Modules\Pos\Events\TableOpened;
+use Modules\Membership\Events\SubscriptionExpiring;
+use Modules\Notifications\Listeners\SendNotification;
+
+class EventServiceProvider extends ServiceProvider
+{
+    protected $listen = [
+        LowStockAlert::class => [SendNotification::class],
+        UnpaidBillAlert::class => [SendNotification::class],
+        TableOpened::class => [SendNotification::class],
+        SubscriptionExpiring::class => [SendNotification::class],
+    ];
+}

--- a/Modules/Notifications/app/Providers/NotificationsServiceProvider.php
+++ b/Modules/Notifications/app/Providers/NotificationsServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\Notifications\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class NotificationsServiceProvider extends ServiceProvider
+{
+    protected string $name = 'Notifications';
+    protected string $nameLower = 'notifications';
+
+    public function boot(): void
+    {
+        $this->publishes([
+            module_path($this->name, 'config/config.php') => config_path('notifications.php'),
+        ], 'config');
+
+        $this->mergeConfigFrom(module_path($this->name, 'config/config.php'), 'notifications');
+    }
+
+    public function register(): void
+    {
+        $this->app->register(EventServiceProvider::class);
+    }
+}

--- a/Modules/Notifications/app/Services/NotificationService.php
+++ b/Modules/Notifications/app/Services/NotificationService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\Notifications\Services;
+
+use Modules\Notifications\Channels\EmailChannel;
+use Modules\Notifications\Channels\InAppChannel;
+use Modules\Notifications\Channels\PushChannel;
+use Modules\Notifications\Channels\SmsChannel;
+
+class NotificationService
+{
+    /** @var array<string, object> */
+    protected array $channels;
+
+    public function __construct()
+    {
+        $this->channels = [
+            'in-app' => new InAppChannel(),
+            'email' => new EmailChannel(),
+            'sms' => new SmsChannel(),
+            'push' => new PushChannel(),
+        ];
+    }
+
+    /**
+     * Send a message through the given channels.
+     *
+     * @param string $message
+     * @param array<int, string> $channels
+     */
+    public function send(string $message, array $channels): void
+    {
+        foreach ($channels as $channel) {
+            $this->channels[$channel]->send($message);
+        }
+    }
+}

--- a/Modules/Notifications/composer.json
+++ b/Modules/Notifications/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "nwidart/notifications",
+    "description": "Notification module",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {
+            }
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Notifications\\": "app/",
+            "Modules\\Notifications\\Database\\Factories\\": "database/factories/",
+            "Modules\\Notifications\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Notifications\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/Notifications/config/config.php
+++ b/Modules/Notifications/config/config.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'channels' => ['in-app', 'email', 'sms', 'push'],
+];
+

--- a/Modules/Notifications/module.json
+++ b/Modules/Notifications/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "Notifications",
+    "alias": "notifications",
+    "description": "Centralized notification dispatch",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\Notifications\\Providers\\NotificationsServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/Pos/app/Events/TableOpened.php
+++ b/Modules/Pos/app/Events/TableOpened.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Modules\Pos\Events;
+
+use App\Models\Tenant;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Modules\Pos\Models\Order;
+
+class TableOpened
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public Order $order, public ?Tenant $tenant = null)
+    {
+    }
+}

--- a/Modules/Pos/app/Http/Controllers/OrderController.php
+++ b/Modules/Pos/app/Http/Controllers/OrderController.php
@@ -4,6 +4,7 @@ namespace Modules\Pos\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Modules\Pos\Events\OrderCreated;
+use Modules\Pos\Events\TableOpened;
 use Illuminate\Http\Request;
 use Modules\Pos\Models\Order;
 
@@ -14,6 +15,7 @@ class OrderController extends Controller
         $order = Order::create($request->only(['tenant_id', 'total', 'status']));
 
         event(new OrderCreated($order, tenant()));
+        event(new TableOpened($order, tenant()));
 
         return response()->json($order, 201);
     }

--- a/Modules/Pos/app/Services/BillingService.php
+++ b/Modules/Pos/app/Services/BillingService.php
@@ -3,6 +3,7 @@
 namespace Modules\Pos\Services;
 
 use Modules\Pos\Models\Order;
+use Modules\Billing\Events\UnpaidBillAlert;
 
 class BillingService
 {
@@ -25,6 +26,7 @@ class BillingService
     public function markAsDebt(Order $order): Order
     {
         $order->is_debt = true;
+        event(new UnpaidBillAlert($order));
         return $order;
     }
 }

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -13,5 +13,6 @@
     "Billing": false,
     "Membership": true,
     "Loyalty": true,
-    "QrOrdering": true
+    "QrOrdering": true,
+    "Notifications": false
 }


### PR DESCRIPTION
## Summary
- scaffold Notifications module with in-app, email, SMS and push channels
- emit alerts for low stock, unpaid bills, table opens and subscription expiry
- wire modules to dispatch and listen for notification events

## Testing
- `composer dump-autoload` (fails: Illuminate\Foundation\ComposerScripts is not autoloadable)
- `phpunit` (fails: command not found)
- `composer test` (fails: @php artisan config:clear --ansi handling the test event returned with error code 255)


------
https://chatgpt.com/codex/tasks/task_e_68c0727c0e38833288f4e5ddb268db4f