### PR TITLE
feat: add HR jobs module

### DIFF
--- a/Modules/HrJobs/app/Http/Controllers/ApplicationController.php
+++ b/Modules/HrJobs/app/Http/Controllers/ApplicationController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\HrJobs\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Modules\HrJobs\Models\Application;
+use Modules\HrJobs\Models\Job;
+
+class ApplicationController extends Controller
+{
+    public function store(Request $request, Job $job)
+    {
+        $data = $request->validate([
+            'member_profile_id' => 'required|exists:member_profiles,id',
+            'resume' => 'nullable|string',
+        ]);
+        $data['job_id'] = $job->id;
+        $data['status'] = 'submitted';
+
+        return Application::create($data);
+    }
+
+    public function update(Request $request, Application $application)
+    {
+        $data = $request->validate([
+            'status' => 'required|string',
+        ]);
+        $application->update($data);
+        return $application;
+    }
+
+    public function show(Application $application)
+    {
+        return $application->load(['job', 'memberProfile']);
+    }
+}

--- a/Modules/HrJobs/app/Http/Controllers/JobController.php
+++ b/Modules/HrJobs/app/Http/Controllers/JobController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Modules\HrJobs\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Modules\HrJobs\Models\Job;
+
+class JobController extends Controller
+{
+    public function index()
+    {
+        return Job::with('applications')->get();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'title' => 'required|string',
+            'description' => 'nullable|string',
+        ]);
+
+        $data['tenant_id'] = $request->user()->tenant_id ?? null;
+        $data['status'] = 'open';
+
+        return Job::create($data);
+    }
+
+    public function show(Job $job)
+    {
+        return $job->load('applications');
+    }
+}

--- a/Modules/HrJobs/app/Models/Application.php
+++ b/Modules/HrJobs/app/Models/Application.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Modules\HrJobs\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Application extends Model
+{
+    protected $fillable = [
+        'job_id',
+        'member_profile_id',
+        'resume',
+        'status',
+    ];
+
+    public function job(): BelongsTo
+    {
+        return $this->belongsTo(Job::class);
+    }
+
+    public function memberProfile(): BelongsTo
+    {
+        return $this->belongsTo('Modules\\Membership\\Models\\MemberProfile');
+    }
+}

--- a/Modules/HrJobs/app/Models/Job.php
+++ b/Modules/HrJobs/app/Models/Job.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Modules\HrJobs\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Job extends Model
+{
+    protected $fillable = [
+        'tenant_id',
+        'title',
+        'description',
+        'status',
+    ];
+
+    public function applications(): HasMany
+    {
+        return $this->hasMany(Application::class);
+    }
+}

--- a/Modules/HrJobs/app/Providers/HrJobsServiceProvider.php
+++ b/Modules/HrJobs/app/Providers/HrJobsServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\HrJobs\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class HrJobsServiceProvider extends ServiceProvider
+{
+    protected string $name = 'HrJobs';
+    protected string $nameLower = 'hrjobs';
+
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(module_path($this->name, 'database/migrations'));
+        $this->loadViewsFrom(module_path($this->name, 'resources/views'), $this->nameLower);
+    }
+
+    public function register(): void
+    {
+        $this->app->register(RouteServiceProvider::class);
+    }
+}

--- a/Modules/HrJobs/app/Providers/RouteServiceProvider.php
+++ b/Modules/HrJobs/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Modules\HrJobs\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    protected string $name = 'HrJobs';
+
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    public function map(): void
+    {
+        $this->mapWebRoutes();
+    }
+
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')->group(module_path($this->name, '/routes/web.php'));
+    }
+}

--- a/Modules/HrJobs/composer.json
+++ b/Modules/HrJobs/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "nwidart/hrjobs",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {}
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\HrJobs\\": "app/",
+            "Modules\\HrJobs\\Database\\Factories\\": "database/factories/",
+            "Modules\\HrJobs\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\HrJobs\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/HrJobs/database/migrations/2024_01_01_100000_create_jobs_table.php
+++ b/Modules/HrJobs/database/migrations/2024_01_01_100000_create_jobs_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('hr_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->nullable()->constrained('tenants');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('status')->default('open');
+            $table->timestamps();
+            $table->index('tenant_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('hr_jobs');
+    }
+};

--- a/Modules/HrJobs/database/migrations/2024_01_01_100001_create_applications_table.php
+++ b/Modules/HrJobs/database/migrations/2024_01_01_100001_create_applications_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('applications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('job_id')->constrained('hr_jobs')->cascadeOnDelete();
+            $table->foreignId('member_profile_id')->constrained('member_profiles');
+            $table->string('resume')->nullable();
+            $table->string('status')->default('submitted');
+            $table->timestamps();
+            $table->index('job_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('applications');
+    }
+};

--- a/Modules/HrJobs/module.json
+++ b/Modules/HrJobs/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "HrJobs",
+    "alias": "hrjobs",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\HrJobs\\Providers\\HrJobsServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/HrJobs/routes/web.php
+++ b/Modules/HrJobs/routes/web.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\HrJobs\Http\Controllers\JobController;
+use Modules\HrJobs\Http\Controllers\ApplicationController;
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::resource('hr-jobs', JobController::class)->only(['index', 'store', 'show']);
+    Route::post('hr-jobs/{job}/apply', [ApplicationController::class, 'store'])->name('hrjobs.apply');
+    Route::get('applications/{application}', [ApplicationController::class, 'show'])->name('hrjobs.applications.show');
+    Route::patch('applications/{application}', [ApplicationController::class, 'update'])->name('hrjobs.applications.update');
+});

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -14,5 +14,6 @@
     "Membership": true,
     "Loyalty": true,
     "QrOrdering": true,
-    "Notifications": false
+    "Notifications": false,
+    "HrJobs": false
 }


### PR DESCRIPTION
## Summary
- scaffold HrJobs module for recruitment
- add job posting and application models and controllers
- create migrations linking applications to membership profiles

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c0757fe9188332859e31432fe4032a