### PR TITLE
Add equipment maintenance module

### DIFF
--- a/Modules/EquipmentMaintenance/app/Console/CheckMaintenanceSchedules.php
+++ b/Modules/EquipmentMaintenance/app/Console/CheckMaintenanceSchedules.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Notification;
+use Modules\EquipmentMaintenance\Models\MaintenanceSchedule;
+use App\Models\User;
+use Modules\EquipmentMaintenance\Notifications\UpcomingMaintenanceNotification;
+
+class CheckMaintenanceSchedules extends Command
+{
+    protected $signature = 'equipment-maintenance:check';
+    protected $description = 'Send alerts for upcoming maintenance';
+
+    public function handle(): int
+    {
+        $schedules = MaintenanceSchedule::where('scheduled_at', '<=', now()->addDays(7))
+            ->where('alerted', false)
+            ->get();
+
+        if ($schedules->isEmpty()) {
+            $this->info('No upcoming maintenance.');
+            return self::SUCCESS;
+        }
+
+        $users = User::all();
+        foreach ($schedules as $schedule) {
+            Notification::send($users, new UpcomingMaintenanceNotification($schedule));
+            $schedule->update(['alerted' => true]);
+        }
+
+        $this->info('Notifications sent.');
+        return self::SUCCESS;
+    }
+}

--- a/Modules/EquipmentMaintenance/app/Http/Controllers/EquipmentController.php
+++ b/Modules/EquipmentMaintenance/app/Http/Controllers/EquipmentController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Modules\EquipmentMaintenance\Models\Equipment;
+
+class EquipmentController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'tenant_id' => 'required|integer',
+            'name' => 'required|string',
+            'serial_number' => 'nullable|string',
+            'description' => 'nullable|string',
+            'purchased_at' => 'nullable|date',
+        ]);
+
+        $equipment = Equipment::create($data);
+
+        return response()->json($equipment, 201);
+    }
+}

--- a/Modules/EquipmentMaintenance/app/Http/Controllers/MaintenanceLogController.php
+++ b/Modules/EquipmentMaintenance/app/Http/Controllers/MaintenanceLogController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Modules\EquipmentMaintenance\Models\MaintenanceLog;
+
+class MaintenanceLogController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'tenant_id' => 'required|integer',
+            'equipment_id' => 'required|integer',
+            'performed_at' => 'required|date',
+            'notes' => 'nullable|string',
+        ]);
+
+        $log = MaintenanceLog::create($data);
+
+        return response()->json($log, 201);
+    }
+}

--- a/Modules/EquipmentMaintenance/app/Http/Controllers/MaintenanceScheduleController.php
+++ b/Modules/EquipmentMaintenance/app/Http/Controllers/MaintenanceScheduleController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Modules\EquipmentMaintenance\Models\MaintenanceSchedule;
+
+class MaintenanceScheduleController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'tenant_id' => 'required|integer',
+            'equipment_id' => 'required|integer',
+            'scheduled_at' => 'required|date',
+            'notes' => 'nullable|string',
+        ]);
+
+        $schedule = MaintenanceSchedule::create($data);
+
+        return response()->json($schedule, 201);
+    }
+}

--- a/Modules/EquipmentMaintenance/app/Models/Equipment.php
+++ b/Modules/EquipmentMaintenance/app/Models/Equipment.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Equipment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'name',
+        'serial_number',
+        'description',
+        'purchased_at',
+    ];
+
+    protected $casts = [
+        'purchased_at' => 'date',
+    ];
+
+    public function schedules()
+    {
+        return $this->hasMany(MaintenanceSchedule::class);
+    }
+
+    public function logs()
+    {
+        return $this->hasMany(MaintenanceLog::class);
+    }
+}

--- a/Modules/EquipmentMaintenance/app/Models/MaintenanceLog.php
+++ b/Modules/EquipmentMaintenance/app/Models/MaintenanceLog.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MaintenanceLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'equipment_id',
+        'performed_at',
+        'notes',
+    ];
+
+    protected $casts = [
+        'performed_at' => 'date',
+    ];
+
+    public function equipment()
+    {
+        return $this->belongsTo(Equipment::class);
+    }
+}

--- a/Modules/EquipmentMaintenance/app/Models/MaintenanceSchedule.php
+++ b/Modules/EquipmentMaintenance/app/Models/MaintenanceSchedule.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MaintenanceSchedule extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'equipment_id',
+        'scheduled_at',
+        'notes',
+        'alerted',
+    ];
+
+    protected $casts = [
+        'scheduled_at' => 'date',
+        'alerted' => 'boolean',
+    ];
+
+    public function equipment()
+    {
+        return $this->belongsTo(Equipment::class);
+    }
+}

--- a/Modules/EquipmentMaintenance/app/Notifications/UpcomingMaintenanceNotification.php
+++ b/Modules/EquipmentMaintenance/app/Notifications/UpcomingMaintenanceNotification.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Modules\EquipmentMaintenance\Models\MaintenanceSchedule;
+
+class UpcomingMaintenanceNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(public MaintenanceSchedule $schedule)
+    {
+    }
+
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Upcoming Maintenance Reminder')
+            ->line('Equipment: ' . $this->schedule->equipment->name)
+            ->line('Scheduled for: ' . $this->schedule->scheduled_at->toDateString())
+            ->line('Thank you.');
+    }
+}

--- a/Modules/EquipmentMaintenance/app/Providers/EquipmentMaintenanceServiceProvider.php
+++ b/Modules/EquipmentMaintenance/app/Providers/EquipmentMaintenanceServiceProvider.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Providers;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\ServiceProvider;
+use Modules\EquipmentMaintenance\Console\CheckMaintenanceSchedules;
+
+class EquipmentMaintenanceServiceProvider extends ServiceProvider
+{
+    protected string $moduleName = 'EquipmentMaintenance';
+    protected string $moduleNameLower = 'equipmentmaintenance';
+
+    public function boot(): void
+    {
+        $this->registerConfig();
+        $this->registerTranslations();
+        $this->registerViews();
+        $this->loadMigrationsFrom(module_path($this->moduleName, 'database/migrations'));
+        $this->loadRoutesFrom(module_path($this->moduleName, 'routes/api.php'));
+        $this->loadRoutesFrom(module_path($this->moduleName, 'routes/web.php'));
+        $this->registerCommands();
+        $this->registerSchedule();
+    }
+
+    public function register(): void {}
+
+    protected function registerConfig(): void
+    {
+        $this->publishes([
+            module_path($this->moduleName, 'config/config.php') => config_path($this->moduleNameLower.'.php'),
+        ], 'config');
+        $this->mergeConfigFrom(
+            module_path($this->moduleName, 'config/config.php'), $this->moduleNameLower
+        );
+    }
+
+    protected function registerTranslations(): void
+    {
+        $langPath = resource_path('lang/modules/'.$this->moduleNameLower);
+
+        if (is_dir($langPath)) {
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom($langPath);
+        } else {
+            $this->loadTranslationsFrom(module_path($this->moduleName, 'resources/lang'), $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom(module_path($this->moduleName, 'resources/lang'));
+        }
+    }
+
+    protected function registerViews(): void
+    {
+        $viewPath = resource_path('views/modules/'.$this->moduleNameLower);
+        $sourcePath = module_path($this->moduleName, 'resources/views');
+        $this->publishes([$sourcePath => $viewPath], ['views', $this->moduleNameLower.'-module-views']);
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->moduleNameLower);
+    }
+
+    protected function getPublishableViewPaths(): array
+    {
+        $paths = [];
+        foreach (config('view.paths') as $path) {
+            if (is_dir($path.'/modules/'.$this->moduleNameLower)) {
+                $paths[] = $path.'/modules/'.$this->moduleNameLower;
+            }
+        }
+        return $paths;
+    }
+
+    protected function registerCommands(): void
+    {
+        $this->commands([CheckMaintenanceSchedules::class]);
+    }
+
+    protected function registerSchedule(): void
+    {
+        $this->app->booted(function () {
+            $schedule = $this->app->make(Schedule::class);
+            $schedule->command(CheckMaintenanceSchedules::class)->daily();
+        });
+    }
+}

--- a/Modules/EquipmentMaintenance/composer.json
+++ b/Modules/EquipmentMaintenance/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "nwidart/equipment-maintenance",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {}
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\EquipmentMaintenance\\": "app/",
+            "Modules\\EquipmentMaintenance\\Database\\Factories\\": "database/factories/",
+            "Modules\\EquipmentMaintenance\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\EquipmentMaintenance\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/EquipmentMaintenance/config/config.php
+++ b/Modules/EquipmentMaintenance/config/config.php
@@ -1,0 +1,2 @@
+<?php
+return [];

--- a/Modules/EquipmentMaintenance/database/migrations/2025_09_09_192529_create_equipment_table.php
+++ b/Modules/EquipmentMaintenance/database/migrations/2025_09_09_192529_create_equipment_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('equipment', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id');
+            $table->string('name');
+            $table->string('serial_number')->nullable();
+            $table->text('description')->nullable();
+            $table->date('purchased_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('equipment');
+    }
+};

--- a/Modules/EquipmentMaintenance/database/migrations/2025_09_09_192556_create_maintenance_schedules_table.php
+++ b/Modules/EquipmentMaintenance/database/migrations/2025_09_09_192556_create_maintenance_schedules_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('maintenance_schedules', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id');
+            $table->foreignId('equipment_id')->constrained('equipment')->cascadeOnDelete();
+            $table->date('scheduled_at');
+            $table->text('notes')->nullable();
+            $table->boolean('alerted')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('maintenance_schedules');
+    }
+};

--- a/Modules/EquipmentMaintenance/database/migrations/2025_09_09_192558_create_maintenance_logs_table.php
+++ b/Modules/EquipmentMaintenance/database/migrations/2025_09_09_192558_create_maintenance_logs_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('maintenance_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('tenant_id');
+            $table->foreignId('equipment_id')->constrained('equipment')->cascadeOnDelete();
+            $table->date('performed_at');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('maintenance_logs');
+    }
+};

--- a/Modules/EquipmentMaintenance/module.json
+++ b/Modules/EquipmentMaintenance/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "EquipmentMaintenance",
+    "alias": "equipmentmaintenance",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\EquipmentMaintenance\\Providers\\EquipmentMaintenanceServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/EquipmentMaintenance/resources/lang/ar/messages.php
+++ b/Modules/EquipmentMaintenance/resources/lang/ar/messages.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'example' => 'مثال',
+];

--- a/Modules/EquipmentMaintenance/resources/lang/en/messages.php
+++ b/Modules/EquipmentMaintenance/resources/lang/en/messages.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'example' => 'Example',
+];

--- a/Modules/EquipmentMaintenance/routes/api.php
+++ b/Modules/EquipmentMaintenance/routes/api.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\EquipmentMaintenance\Http\Controllers\EquipmentController;
+use Modules\EquipmentMaintenance\Http\Controllers\MaintenanceScheduleController;
+use Modules\EquipmentMaintenance\Http\Controllers\MaintenanceLogController;
+
+Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
+    Route::post('equipment', [EquipmentController::class, 'store'])->name('equipment.store');
+    Route::post('maintenance-schedules', [MaintenanceScheduleController::class, 'store'])->name('maintenance-schedules.store');
+    Route::post('maintenance-logs', [MaintenanceLogController::class, 'store'])->name('maintenance-logs.store');
+});

--- a/Modules/EquipmentMaintenance/routes/web.php
+++ b/Modules/EquipmentMaintenance/routes/web.php
@@ -1,0 +1,5 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+// EquipmentMaintenance module routes

--- a/Modules/EquipmentMaintenance/tests/Feature/EquipmentMaintenanceModuleTest.php
+++ b/Modules/EquipmentMaintenance/tests/Feature/EquipmentMaintenanceModuleTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Tests\Feature;
+
+use Tests\TestCase;
+
+class EquipmentMaintenanceModuleTest extends TestCase
+{
+    public function test_example(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -16,5 +16,6 @@
     "QrOrdering": true,
     "Notifications": false,
     "HrJobs": false,
-    "Rentals": false
+    "Rentals": false,
+    "EquipmentMaintenance": true
 }


### PR DESCRIPTION
## Summary
- scaffold EquipmentMaintenance module with migrations and routes
- record equipment details, maintenance schedules and logs
- notify users about upcoming maintenance via scheduled command

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68c07edab75483328eb61ed5122a50cb