### PR TITLE
feat: configure all modules with default enabled status

### DIFF
--- a/config/modules.php
+++ b/config/modules.php
@@ -16,9 +16,25 @@ return [
     'namespace' => 'Modules',
 
     'modules' => [
+        'Billing' => ['enabled' => false],
+        'Core' => ['enabled' => true],
+        'Crm' => ['enabled' => true],
+        'EquipmentMaintenance' => ['enabled' => true],
+        'FloorPlanDesigner' => ['enabled' => false],
+        'HrJobs' => ['enabled' => false],
+        'Inventory' => ['enabled' => false],
+        'Jobs' => ['enabled' => false],
+        'Kds' => ['enabled' => true],
+        'Loyalty' => ['enabled' => true],
+        'Marketplace' => ['enabled' => false],
+        'Membership' => ['enabled' => true],
+        'Notifications' => ['enabled' => false],
         'Pos' => ['enabled' => true],
-        'Inventory' => ['enabled' => true],
-        'Crm' => ['enabled' => false],
+        'Procurement' => ['enabled' => false],
+        'QrOrdering' => ['enabled' => true],
+        'Rentals' => ['enabled' => false],
+        'Reports' => ['enabled' => true],
+        'SuperAdmin' => ['enabled' => false],
     ],
 
     /*


### PR DESCRIPTION
## Summary
- enumerate all module directories in `config/modules.php`
- set default enabled state for each module

## Testing
- `php artisan module:list`
- `php artisan module:enable Billing`
- `php artisan module:disable Billing`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68c082f67dfc833287df91067007343f