### PR TITLE
Add waiter order move and split functionality

### DIFF
--- a/Modules/Pos/app/Models/Order.php
+++ b/Modules/Pos/app/Models/Order.php
@@ -24,6 +24,12 @@ class Order extends Model implements Auditable
         'total',
         'status',
         'is_debt',
+        'table_id',
+        'split',
+    ];
+
+    protected $casts = [
+        'split' => 'array',
     ];
 
     public function tenant(): \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/Modules/Pos/database/migrations/2025_09_09_033249_create_orders_table.php
+++ b/Modules/Pos/database/migrations/2025_09_09_033249_create_orders_table.php
@@ -16,10 +16,13 @@ return new class extends Migration
             $table->foreignId('tenant_id');
             $table->decimal('total', 10, 2);
             $table->enum('status', ['pending', 'completed']);
+            $table->unsignedBigInteger('table_id')->nullable();
+            $table->json('split')->nullable();
             $table->timestamps();
             $table->softDeletes();
 
             $table->index('tenant_id');
+            $table->index('table_id');
         });
     }
 

--- a/Modules/Pos/resources/js/components/MoveOrder.vue
+++ b/Modules/Pos/resources/js/components/MoveOrder.vue
@@ -1,0 +1,20 @@
+<template>
+  <form @submit.prevent="submit">
+    <input v-model="orderId" placeholder="Order ID" />
+    <input v-model="tableId" placeholder="Table ID" />
+    <button type="submit">Move</button>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import axios from 'axios';
+
+const orderId = ref('');
+const tableId = ref('');
+
+function submit() {
+  axios.post(`/waiter/orders/${orderId.value}/move`, { table_id: tableId.value })
+    .then(response => alert(response.data.message));
+}
+</script>

--- a/Modules/Pos/resources/js/components/SplitBill.vue
+++ b/Modules/Pos/resources/js/components/SplitBill.vue
@@ -1,0 +1,20 @@
+<template>
+  <form @submit.prevent="submit">
+    <input v-model="orderId" placeholder="Order ID" />
+    <input v-model.number="parts" placeholder="Parts" />
+    <button type="submit">Split</button>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import axios from 'axios';
+
+const orderId = ref('');
+const parts = ref(2);
+
+function submit() {
+  axios.post(`/waiter/orders/${orderId.value}/split`, { parts: parts.value })
+    .then(response => alert(response.data.message));
+}
+</script>

--- a/Modules/Pos/resources/js/components/WaiterApp.vue
+++ b/Modules/Pos/resources/js/components/WaiterApp.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <MoveOrder />
+    <SplitBill />
+  </div>
+</template>
+
+<script setup>
+import MoveOrder from './MoveOrder.vue';
+import SplitBill from './SplitBill.vue';
+</script>

--- a/Modules/Pos/resources/js/waiter.js
+++ b/Modules/Pos/resources/js/waiter.js
@@ -1,7 +1,4 @@
-export function moveOrder(orderId, fromTable, toTable) {
-    console.log(`Move order ${orderId} from table ${fromTable} to ${toTable}`);
-}
+import { createApp } from 'vue';
+import WaiterApp from './components/WaiterApp.vue';
 
-export function splitBill(orderId, parts) {
-    console.log(`Split order ${orderId} into ${parts} parts`);
-}
+createApp(WaiterApp).mount('#waiter-app');

--- a/Modules/Pos/routes/web.php
+++ b/Modules/Pos/routes/web.php
@@ -7,4 +7,6 @@ use Modules\Pos\Http\Controllers\WaiterController;
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('pos', PosController::class)->names('pos');
     Route::get('waiter', [WaiterController::class, 'index'])->name('pos.waiter');
+    Route::post('waiter/orders/{order}/move', [WaiterController::class, 'move'])->name('pos.waiter.move');
+    Route::post('waiter/orders/{order}/split', [WaiterController::class, 'split'])->name('pos.waiter.split');
 });

--- a/Modules/Pos/tests/Feature/WaiterControllerTest.php
+++ b/Modules/Pos/tests/Feature/WaiterControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Modules\Pos\Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Http\Middleware\InitializeTenancyByDomain;
+use App\Http\Middleware\SetUserLocale;
+use Modules\Pos\Models\Order;
+use Modules\Pos\Events\TableOpened;
+
+class WaiterControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware([
+            InitializeTenancyByDomain::class,
+            SetUserLocale::class,
+        ]);
+        $user = User::factory()->create(['tenant_id' => 1]);
+        $this->actingAs($user);
+    }
+
+    public function test_move_updates_table_and_emits_event(): void
+    {
+        Event::fake();
+
+        $order = Order::create([
+            'tenant_id' => 1,
+            'total' => 100,
+            'status' => 'pending',
+            'table_id' => 1,
+        ]);
+
+        $response = $this->postJson("/waiter/orders/{$order->id}/move", [
+            'table_id' => 2,
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['message' => __('pos.moved')]);
+        $this->assertDatabaseHas('orders', [
+            'id' => $order->id,
+            'table_id' => 2,
+        ]);
+        Event::assertDispatched(TableOpened::class);
+    }
+
+    public function test_split_persists_parts(): void
+    {
+        $order = Order::create([
+            'tenant_id' => 1,
+            'total' => 100,
+            'status' => 'pending',
+            'table_id' => 1,
+        ]);
+
+        $response = $this->postJson("/waiter/orders/{$order->id}/split", [
+            'parts' => 2,
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'message' => __('pos.split'),
+            'parts' => [50.0, 50.0],
+        ]);
+
+        $order->refresh();
+        $this->assertEquals([50.0, 50.0], $order->split);
+    }
+}

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -6,6 +6,8 @@
   "pos.created": "تم إنشاء عنصر القائمة",
   "pos.updated": "تم تحديث عنصر القائمة",
   "pos.deleted": "تم حذف عنصر القائمة",
+  "pos.moved": "تم نقل الطلب",
+  "pos.split": "تم تقسيم الفاتورة بنجاح",
   "floorPlanDesigner.title": "مصمم مخطط الطابق",
   "floorPlanDesigner.addTable": "إضافة طاولة",
   "floorPlanDesigner.addChair": "إضافة كرسي",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,6 +6,8 @@
   "pos.created": "Menu item created",
   "pos.updated": "Menu item updated",
   "pos.deleted": "Menu item deleted",
+  "pos.moved": "Order moved",
+  "pos.split": "Bill split successfully",
   "floorPlanDesigner.title": "Floor Plan Designer",
   "floorPlanDesigner.addTable": "Add table",
   "floorPlanDesigner.addChair": "Add chair",


### PR DESCRIPTION
## Summary
- allow moving orders between tables and splitting bills
- add waiter UI components for move and split
- cover move and split features with tests

## Testing
- `vendor/bin/phpunit Modules/Pos/tests/Feature/WaiterControllerTest.php Modules/Pos/tests/Feature/PosControllerTest.php Modules/Pos/tests/Unit/BillingServiceTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c085d0ebdc8332b6a94113b54d6377