### PR TITLE
Persist debt flag and send unpaid alert

### DIFF
--- a/Modules/Pos/app/Services/BillingService.php
+++ b/Modules/Pos/app/Services/BillingService.php
@@ -21,12 +21,21 @@ class BillingService
     }
 
     /**
-     * Mark the given order as debt without persisting.
+     * Mark the given order as debt and persist the change.
+     *
+     * If the order is already marked as debt, no action is taken.
      */
     public function markAsDebt(Order $order): Order
     {
+        if ($order->is_debt) {
+            return $order;
+        }
+
         $order->is_debt = true;
+        $order->save();
+
         event(new UnpaidBillAlert($order));
+
         return $order;
     }
 }

--- a/Modules/Pos/tests/Unit/BillingServiceTest.php
+++ b/Modules/Pos/tests/Unit/BillingServiceTest.php
@@ -2,12 +2,18 @@
 
 namespace Modules\Pos\Tests\Unit;
 
+use Illuminate\Support\Facades\Event;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Modules\Billing\Events\UnpaidBillAlert;
 use Modules\Pos\Models\Order;
 use Modules\Pos\Services\BillingService;
 use Tests\TestCase;
 
 class BillingServiceTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     public function test_split_bill_creates_parts()
     {
         $order = new Order(['total' => 100]);
@@ -17,11 +23,35 @@ class BillingServiceTest extends TestCase
         $this->assertEquals(50, $parts[0]);
     }
 
-    public function test_mark_as_debt_sets_flag()
+    public function test_mark_as_debt_persists_and_dispatches_event()
     {
-        $order = new Order(['total' => 100]);
+        Event::fake();
+
+        $order = Mockery::mock(Order::class)->makePartial();
+        $order->total = 100;
+        $order->shouldReceive('save')->once()->andReturnTrue();
+
         $service = new BillingService();
         $service->markAsDebt($order);
+
         $this->assertTrue($order->is_debt);
+
+        Event::assertDispatched(UnpaidBillAlert::class, function ($event) use ($order) {
+            return $event->order === $order;
+        });
+    }
+
+    public function test_mark_as_debt_skips_when_already_flagged()
+    {
+        Event::fake();
+
+        $order = Mockery::mock(Order::class)->makePartial();
+        $order->is_debt = true;
+        $order->shouldNotReceive('save');
+
+        $service = new BillingService();
+        $service->markAsDebt($order);
+
+        Event::assertNotDispatched(UnpaidBillAlert::class);
     }
 }


### PR DESCRIPTION
## Summary
- persist debt flag on orders and dispatch UnpaidBillAlert only once
- test debt marking persistence and alert firing

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c0890159d0833287c2de83707d4304