### PR TITLE
Add tenant scoping to POS orders

### DIFF
--- a/Modules/Pos/app/Models/Order.php
+++ b/Modules/Pos/app/Models/Order.php
@@ -16,6 +16,21 @@ class Order extends Model implements Auditable
     use SoftDeletes;
     use AuditableTrait;
 
+    protected static function booted(): void
+    {
+        static::addGlobalScope('tenant', function ($q): void {
+            if (function_exists('tenant') && tenant()) {
+                $q->where('tenant_id', tenant('id'));
+            }
+        });
+
+        static::creating(function (self $order): void {
+            if (function_exists('tenant') && tenant()) {
+                $order->tenant_id ??= tenant('id');
+            }
+        });
+    }
+
     /**
      * The attributes that are mass assignable.
      */

--- a/tests/Unit/OrderTenantScopeTest.php
+++ b/tests/Unit/OrderTenantScopeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Modules\Pos\Models {
+    function tenant($key = null) {
+        $tenant = \Tests\Unit\TenantContext::$tenant;
+        if (! $tenant) {
+            return null;
+        }
+        return $key ? $tenant->{$key} : $tenant;
+    }
+}
+
+namespace Tests\Unit {
+
+use App\Models\Tenant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\Pos\Models\Order;
+use Tests\TestCase;
+
+class TenantContext
+{
+    public static ?Tenant $tenant = null;
+}
+
+class OrderTenantScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tenant_id_is_set_on_creation(): void
+    {
+        $tenant = new Tenant(['id' => 1]);
+        TenantContext::$tenant = $tenant;
+
+        $order = Order::create([
+            'total' => 100,
+            'status' => 'pending',
+        ]);
+
+        $this->assertSame(1, $order->tenant_id);
+    }
+
+    public function test_orders_are_isolated_by_tenant(): void
+    {
+        $tenant1 = new Tenant(['id' => 1]);
+        TenantContext::$tenant = $tenant1;
+        Order::create(['total' => 10, 'status' => 'pending']);
+
+        $tenant2 = new Tenant(['id' => 2]);
+        TenantContext::$tenant = $tenant2;
+        Order::create(['total' => 20, 'status' => 'pending']);
+
+        TenantContext::$tenant = $tenant1;
+        $this->assertCount(1, Order::all());
+
+        TenantContext::$tenant = $tenant2;
+        $this->assertCount(1, Order::all());
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- scope POS orders to current tenant via global scope and default tenant assignment
- test tenant-scoped order isolation

## Testing
- `php artisan test tests/Unit/OrderTenantScopeTest.php`
- `composer test` *(fails: Modules\Pos\Tests\Feature\WaiterControllerTest > split persists parts)*

------
https://chatgpt.com/codex/tasks/task_e_68c08a78232483329b7c922b44b5a575