### PR TITLE
test(billing): add module tests and coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           php-version: '8.3'
           extensions: mbstring, intl, pdo_mysql, dom, fileinfo
-          coverage: none
+          coverage: xdebug
       - name: Install PHP dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Install Node dependencies

--- a/Modules/Billing/app/Models/Plan.php
+++ b/Modules/Billing/app/Models/Plan.php
@@ -14,4 +14,9 @@ class Plan extends Model
         'price',
         'trial_days',
     ];
+
+    protected static function newFactory(): \Modules\Billing\Database\Factories\PlanFactory
+    {
+        return \Modules\Billing\Database\Factories\PlanFactory::new();
+    }
 }

--- a/Modules/Billing/database/factories/PlanFactory.php
+++ b/Modules/Billing/database/factories/PlanFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Modules\Billing\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Modules\Billing\Models\Plan;
+
+class PlanFactory extends Factory
+{
+    protected $model = Plan::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+            'price' => $this->faker->randomFloat(2, 1, 100),
+            'trial_days' => $this->faker->numberBetween(0, 30),
+        ];
+    }
+}

--- a/Modules/Billing/tests/Feature/PlanControllerTest.php
+++ b/Modules/Billing/tests/Feature/PlanControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\Billing\Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Modules\Billing\Http\Controllers\PlanController;
+use Modules\Billing\Models\Plan;
+use Tests\TestCase;
+
+class PlanControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_returns_plans(): void
+    {
+        Artisan::call('migrate', ['--path' => 'Modules/Billing/database/migrations', '--realpath' => true]);
+        Plan::factory()->create();
+
+        $response = app(PlanController::class)->index();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertCount(1, $response->getData(true));
+    }
+}

--- a/Modules/Billing/tests/Unit/PaymentGatewayManagerTest.php
+++ b/Modules/Billing/tests/Unit/PaymentGatewayManagerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\Billing\Tests\Unit;
+
+use Modules\Billing\Services\PaymentGatewayManager;
+use PHPUnit\Framework\TestCase;
+
+class PaymentGatewayManagerTest extends TestCase
+{
+    public function test_create_subscription_returns_payload(): void
+    {
+        $manager = new PaymentGatewayManager(['stripe' => []]);
+        $result = $manager->createSubscription('stripe', ['plan' => 'basic']);
+
+        $this->assertSame('stripe', $result['provider']);
+        $this->assertSame(['plan' => 'basic'], $result['payload']);
+    }
+
+    public function test_unknown_provider_throws_exception(): void
+    {
+        $manager = new PaymentGatewayManager([]);
+        $this->expectException(\RuntimeException::class);
+        $manager->createSubscription('foo', []);
+    }
+}

--- a/Modules/Billing/tests/Unit/UnpaidBillAlertTest.php
+++ b/Modules/Billing/tests/Unit/UnpaidBillAlertTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Modules\Billing\Tests\Unit;
+
+use Illuminate\Support\Facades\Event;
+use Modules\Billing\Events\UnpaidBillAlert;
+use Modules\Pos\Models\Order;
+use Tests\TestCase;
+
+class UnpaidBillAlertTest extends TestCase
+{
+    public function test_event_dispatches_with_order(): void
+    {
+        Event::fake();
+        $order = Order::factory()->make();
+
+        event(new UnpaidBillAlert($order));
+
+        Event::assertDispatched(UnpaidBillAlert::class, fn ($e) => $e->order === $order);
+    }
+}

--- a/Modules/Inventory/tests/Unit/InventoryServiceTest.php
+++ b/Modules/Inventory/tests/Unit/InventoryServiceTest.php
@@ -8,6 +8,7 @@ use Modules\Inventory\Events\LowStockAlert;
 use Modules\Inventory\Models\InventoryItem;
 use Modules\Inventory\Models\StockMovement;
 use Modules\Inventory\Services\InventoryService;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class InventoryServiceTest extends TestCase
@@ -24,7 +25,7 @@ class InventoryServiceTest extends TestCase
         $this->service = new InventoryService();
     }
 
-    /** @test */
+    #[Test]
     public function it_deducts_stock_using_fifo(): void
     {
         $item = InventoryItem::create(['tenant_id' => 1, 'name' => 'Beans', 'quantity' => 0, 'alert_threshold' => 0]);
@@ -45,7 +46,7 @@ class InventoryServiceTest extends TestCase
         $this->assertEquals(5, $last->remaining_quantity);
     }
 
-    /** @test */
+    #[Test]
     public function it_deducts_stock_using_lifo(): void
     {
         $item = InventoryItem::create(['tenant_id' => 1, 'name' => 'Beans', 'quantity' => 0, 'alert_threshold' => 0]);
@@ -66,7 +67,7 @@ class InventoryServiceTest extends TestCase
         $this->assertEquals(0, $last->remaining_quantity);
     }
 
-    /** @test */
+    #[Test]
     public function it_dispatches_low_stock_alert(): void
     {
         Event::fake([LowStockAlert::class]);

--- a/Modules/Pos/app/Models/Order.php
+++ b/Modules/Pos/app/Models/Order.php
@@ -75,4 +75,9 @@ class Order extends Model implements Auditable
     {
         return $this->toReportArray();
     }
+
+    protected static function newFactory(): \Modules\Pos\Database\Factories\OrderFactory
+    {
+        return \Modules\Pos\Database\Factories\OrderFactory::new();
+    }
 }

--- a/Modules/Pos/database/factories/OrderFactory.php
+++ b/Modules/Pos/database/factories/OrderFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Modules\Pos\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Modules\Pos\Models\Order;
+
+class OrderFactory extends Factory
+{
+    protected $model = Order::class;
+
+    public function definition(): array
+    {
+        return [
+            'tenant_id' => 1,
+            'total' => $this->faker->randomFloat(2, 10, 100),
+            'status' => 'open',
+        ];
+    }
+}

--- a/Modules/Procurement/tests/Unit/PurchaseOrderServiceTest.php
+++ b/Modules/Procurement/tests/Unit/PurchaseOrderServiceTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Modules\Procurement\Models\Supplier;
 use Modules\Procurement\Services\PurchaseOrderService;
 use Modules\Core\Contracts\InventoryServiceInterface;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class PurchaseOrderServiceTest extends TestCase
@@ -19,7 +20,7 @@ class PurchaseOrderServiceTest extends TestCase
         $this->artisan('migrate', ['--path' => 'Modules/Procurement/database/migrations', '--realpath' => true]);
     }
 
-    /** @test */
+    #[Test]
     public function it_restocks_inventory_when_order_completed(): void
     {
         $items = [['id' => 1, 'quantity' => 10, 'unit_cost' => 0]];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,14 @@
     <source>
         <include>
             <directory>app</directory>
+            <directory>Modules</directory>
         </include>
     </source>
+    <coverage>
+        <report>
+            <text outputFile="php://stdout" showUncoveredFiles="false"/>
+        </report>
+    </coverage>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>

--- a/tests/Feature/ModuleAccessTest.php
+++ b/tests/Feature/ModuleAccessTest.php
@@ -6,15 +6,14 @@ use App\Models\User;
 use App\Http\Middleware\SetUserLocale;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ModuleAccessTest extends TestCase
 {
     use RefreshDatabase;
 
-    /**
-     * @dataProvider activeModuleProvider
-     */
+    #[DataProvider('activeModuleProvider')]
     public function test_active_module_index_route_accessible(string $path, string $view): void
     {
         $this->withoutMiddleware([SetUserLocale::class]);

--- a/tests/Ui/ModuleContentTest.php
+++ b/tests/Ui/ModuleContentTest.php
@@ -5,15 +5,14 @@ namespace Tests\Ui;
 use App\Models\User;
 use App\Http\Middleware\SetUserLocale;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ModuleContentTest extends TestCase
 {
     use RefreshDatabase;
 
-    /**
-     * @dataProvider activeModuleProvider
-     */
+    #[DataProvider('activeModuleProvider')]
     public function test_index_page_shows_module_name(string $path, string $name): void
     {
         $this->withoutMiddleware([SetUserLocale::class]);

--- a/tests/Unit/ModuleConfigTest.php
+++ b/tests/Unit/ModuleConfigTest.php
@@ -2,13 +2,12 @@
 
 namespace Tests\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ModuleConfigTest extends TestCase
 {
-    /**
-     * @dataProvider moduleProvider
-     */
+    #[DataProvider('moduleProvider')]
     public function test_module_alias_matches_folder(string $folder, string $expected): void
     {
         $path = dirname(__DIR__, 2)."/Modules/{$folder}/module.json";


### PR DESCRIPTION
## Summary
- add billing Plan and POS Order factories
- cover Billing controller, service, and event with module tests
- include modules in phpunit coverage reporting

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit Modules/Billing/tests/Unit/PaymentGatewayManagerTest.php Modules/Billing/tests/Unit/UnpaidBillAlertTest.php Modules/Billing/tests/Feature/PlanControllerTest.php`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c09661ac648332a8185a7285c79e34