### PR TITLE
Add tenant currency support

### DIFF
--- a/app/Support/CurrencyFormatter.php
+++ b/app/Support/CurrencyFormatter.php
@@ -9,8 +9,17 @@ class CurrencyFormatter
     public static function format(float $amount): string
     {
         $currency = config('app.currency', 'USD');
+
+        if (function_exists('tenant')) {
+            $tenantCurrency = tenant('currency');
+            if ($tenantCurrency) {
+                $currency = $tenantCurrency;
+            }
+        }
+
         $locale = app()->getLocale();
         $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
+
         return $formatter->formatCurrency($amount, $currency);
     }
 }

--- a/database/migrations/central/2019_09_15_000030_add_currency_to_tenants_table.php
+++ b/database/migrations/central/2019_09_15_000030_add_currency_to_tenants_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->string('currency')->default(config('app.currency', 'USD'))->after('plan_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->dropColumn('currency');
+        });
+    }
+};

--- a/tests/Unit/CurrencyFormatterTest.php
+++ b/tests/Unit/CurrencyFormatterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Support {
+    if (! function_exists(__NAMESPACE__ . '\\tenant')) {
+        function tenant($key = null) {
+            $tenant = \Tests\Unit\CurrencyFormatterTenantContext::$tenant;
+            if (! $tenant) {
+                return null;
+            }
+            return $key ? $tenant->{$key} : $tenant;
+        }
+    }
+}
+
+namespace Tests\Unit {
+
+use App\Models\Tenant;
+use App\Support\CurrencyFormatter;
+use Modules\Pos\Models\MenuItem;
+use Modules\Pos\Models\Order;
+use NumberFormatter;
+use Tests\TestCase;
+
+class CurrencyFormatterTenantContext
+{
+    public static ?Tenant $tenant = null;
+}
+
+class CurrencyFormatterTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        CurrencyFormatterTenantContext::$tenant = null;
+        app()->forgetInstance('tenant');
+    }
+
+    public function test_it_uses_tenant_currency_when_available(): void
+    {
+        $tenant = new Tenant(['id' => 1, 'currency' => 'EUR']);
+        CurrencyFormatterTenantContext::$tenant = $tenant;
+
+        $formatter = new NumberFormatter(app()->getLocale(), NumberFormatter::CURRENCY);
+
+        $this->assertSame(
+            $formatter->formatCurrency(10, 'EUR'),
+            CurrencyFormatter::format(10)
+        );
+
+        $menuItem = new MenuItem(['price' => 5]);
+        $this->assertSame(
+            $formatter->formatCurrency(5, 'EUR'),
+            $menuItem->formatted_price
+        );
+
+        $order = new Order(['total' => 20]);
+        $this->assertSame(
+            $formatter->formatCurrency(20, 'EUR'),
+            $order->formatted_total
+        );
+    }
+
+    public function test_it_falls_back_to_app_currency_when_tenant_not_available(): void
+    {
+        CurrencyFormatterTenantContext::$tenant = null;
+        config(['app.currency' => 'USD']);
+
+        $formatter = new NumberFormatter(app()->getLocale(), NumberFormatter::CURRENCY);
+
+        $this->assertSame(
+            $formatter->formatCurrency(10, 'USD'),
+            CurrencyFormatter::format(10)
+        );
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- allow tenants to specify their own currency
- format money using tenant currency when available
- test currency formatting for menu items and orders

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c0a0423d04833287460d18eadd2b36