### PR TITLE
Add equipment monitoring module

### DIFF
--- a/Modules/EquipmentMonitoring/app/Http/Controllers/DashboardController.php
+++ b/Modules/EquipmentMonitoring/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Modules\EquipmentMonitoring\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Modules\EquipmentMonitoring\Models\Device;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        $devices = Device::with(['readings' => fn($q) => $q->latest()->limit(1)])->get();
+        return view('equipmentmonitoring::dashboard', compact('devices'));
+    }
+}

--- a/Modules/EquipmentMonitoring/app/Http/Controllers/DeviceController.php
+++ b/Modules/EquipmentMonitoring/app/Http/Controllers/DeviceController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Modules\EquipmentMonitoring\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use Modules\EquipmentMonitoring\Models\Device;
+
+class DeviceController extends Controller
+{
+    public function index()
+    {
+        return Device::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string',
+            'location' => 'nullable|string',
+            'temperature_threshold' => 'required|numeric',
+        ]);
+
+        $device = Device::create($data);
+
+        return response()->json($device, 201);
+    }
+}

--- a/Modules/EquipmentMonitoring/app/Http/Controllers/ReadingController.php
+++ b/Modules/EquipmentMonitoring/app/Http/Controllers/ReadingController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Modules\EquipmentMonitoring\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use Modules\EquipmentMonitoring\Models\Alert;
+use Modules\EquipmentMonitoring\Models\Device;
+
+class ReadingController extends Controller
+{
+    public function store(Request $request, $device)
+    {
+        $data = $request->validate([
+            'temperature' => 'nullable|numeric',
+            'status' => 'required|string',
+        ]);
+
+        $device = Device::findOrFail($device);
+        $reading = $device->readings()->create($data);
+
+        $alert = null;
+        if (isset($data['temperature']) && $data['temperature'] > $device->temperature_threshold) {
+            $alert = $device->alerts()->create([
+                'message' => 'High temperature: '.$data['temperature'],
+            ]);
+        }
+
+        if (strtolower($data['status']) !== 'ok') {
+            $alert = $device->alerts()->create([
+                'message' => 'Status: '.$data['status'],
+            ]);
+        }
+
+        return response()->json([
+            'reading' => $reading,
+            'alert' => $alert,
+        ], 201);
+    }
+}

--- a/Modules/EquipmentMonitoring/app/Models/Alert.php
+++ b/Modules/EquipmentMonitoring/app/Models/Alert.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Modules\EquipmentMonitoring\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Alert extends Model
+{
+    use HasFactory;
+
+    public $timestamps = true;
+
+    protected $fillable = [
+        'device_id',
+        'message',
+    ];
+
+    public function device()
+    {
+        return $this->belongsTo(Device::class);
+    }
+}

--- a/Modules/EquipmentMonitoring/app/Models/Device.php
+++ b/Modules/EquipmentMonitoring/app/Models/Device.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\EquipmentMonitoring\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Device extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'location',
+        'temperature_threshold',
+    ];
+
+    public function readings()
+    {
+        return $this->hasMany(Reading::class);
+    }
+
+    public function alerts()
+    {
+        return $this->hasMany(Alert::class);
+    }
+}

--- a/Modules/EquipmentMonitoring/app/Models/Reading.php
+++ b/Modules/EquipmentMonitoring/app/Models/Reading.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\EquipmentMonitoring\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Reading extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'device_id',
+        'temperature',
+        'status',
+    ];
+
+    public function device()
+    {
+        return $this->belongsTo(Device::class);
+    }
+}

--- a/Modules/EquipmentMonitoring/app/Providers/EquipmentMonitoringServiceProvider.php
+++ b/Modules/EquipmentMonitoring/app/Providers/EquipmentMonitoringServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Modules\EquipmentMonitoring\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class EquipmentMonitoringServiceProvider extends ServiceProvider
+{
+    protected string $moduleName = 'EquipmentMonitoring';
+    protected string $moduleNameLower = 'equipmentmonitoring';
+
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(module_path($this->moduleName, 'database/migrations'));
+        $this->loadRoutesFrom(module_path($this->moduleName, 'routes/api.php'));
+        $this->loadRoutesFrom(module_path($this->moduleName, 'routes/web.php'));
+        $this->loadViewsFrom(module_path($this->moduleName, 'resources/views'), $this->moduleNameLower);
+    }
+
+    public function register(): void
+    {
+        //
+    }
+}

--- a/Modules/EquipmentMonitoring/composer.json
+++ b/Modules/EquipmentMonitoring/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "nwidart/equipment-monitoring",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {}
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\EquipmentMonitoring\\": "app/",
+            "Modules\\EquipmentMonitoring\\Database\\Factories\\": "database/factories/",
+            "Modules\\EquipmentMonitoring\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\EquipmentMonitoring\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230000_create_devices_table.php
+++ b/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230000_create_devices_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('devices', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('location')->nullable();
+            $table->float('temperature_threshold');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('devices');
+    }
+};

--- a/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230010_create_readings_table.php
+++ b/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230010_create_readings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('readings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('device_id')->constrained('devices')->cascadeOnDelete();
+            $table->float('temperature')->nullable();
+            $table->string('status');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('readings');
+    }
+};

--- a/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230020_create_alerts_table.php
+++ b/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230020_create_alerts_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('alerts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('device_id')->constrained('devices')->cascadeOnDelete();
+            $table->string('message');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('alerts');
+    }
+};

--- a/Modules/EquipmentMonitoring/module.json
+++ b/Modules/EquipmentMonitoring/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "EquipmentMonitoring",
+    "alias": "equipmentmonitoring",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\EquipmentMonitoring\\Providers\\EquipmentMonitoringServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/EquipmentMonitoring/resources/views/dashboard.blade.php
+++ b/Modules/EquipmentMonitoring/resources/views/dashboard.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1>Equipment Status</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Temperature</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach($devices as $device)
+            <tr>
+                <td>{{ $device->name }}</td>
+                <td>{{ optional($device->readings->first())->temperature ?? 'N/A' }}</td>
+                <td>{{ optional($device->readings->first())->status ?? 'N/A' }}</td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+@endsection

--- a/Modules/EquipmentMonitoring/routes/api.php
+++ b/Modules/EquipmentMonitoring/routes/api.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\EquipmentMonitoring\Http\Controllers\DeviceController;
+use Modules\EquipmentMonitoring\Http\Controllers\ReadingController;
+
+Route::prefix('equipment-monitoring')->group(function () {
+    Route::get('devices', [DeviceController::class, 'index']);
+    Route::post('devices', [DeviceController::class, 'store']);
+    Route::post('devices/{device}/readings', [ReadingController::class, 'store']);
+});

--- a/Modules/EquipmentMonitoring/routes/web.php
+++ b/Modules/EquipmentMonitoring/routes/web.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\EquipmentMonitoring\Http\Controllers\DashboardController;
+
+Route::get('equipment-monitoring/dashboard', [DashboardController::class, 'index']);

--- a/Modules/EquipmentMonitoring/tests/Feature/EquipmentMonitoringModuleTest.php
+++ b/Modules/EquipmentMonitoring/tests/Feature/EquipmentMonitoringModuleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\EquipmentMonitoring\Tests\Feature;
+
+use App\Http\Middleware\SetUserLocale;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\EquipmentMonitoring\Models\Device;
+use Tests\TestCase;
+
+class EquipmentMonitoringModuleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(SetUserLocale::class);
+    }
+
+    public function test_reading_triggers_alert(): void
+    {
+        $device = Device::create([
+            'name' => 'Fridge 1',
+            'temperature_threshold' => 5,
+        ]);
+
+        $response = $this->postJson("/equipment-monitoring/devices/{$device->id}/readings", [
+            'temperature' => 10,
+            'status' => 'ok',
+        ]);
+
+        $response->assertCreated();
+        $this->assertDatabaseHas('alerts', [
+            'device_id' => $device->id,
+        ]);
+    }
+}

--- a/config/modules.php
+++ b/config/modules.php
@@ -20,6 +20,7 @@ return [
         'Core' => ['enabled' => true],
         'Crm' => ['enabled' => true],
         'EquipmentMaintenance' => ['enabled' => true],
+        'EquipmentMonitoring' => ['enabled' => true],
         'FloorPlanDesigner' => ['enabled' => false],
         'HrJobs' => ['enabled' => false],
         'Inventory' => ['enabled' => false],

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -19,5 +19,6 @@
     "Rentals": false,
     "EquipmentMaintenance": true,
     "TableReservations": true,
-    "SelfServiceKiosk": true
+    "SelfServiceKiosk": true,
+    "EquipmentMonitoring": true
 }


### PR DESCRIPTION
## Summary
- add EquipmentMonitoring module with device registration and sensor ingestion endpoints
- store readings with alert triggers and dashboard view

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68c0b181ba9c833291110ae1b7db725b