### PR TITLE
Add purchase history and promotions scaffold

### DIFF
--- a/app/Http/Controllers/PromotionController.php
+++ b/app/Http/Controllers/PromotionController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Notifications\PromotionNotification;
+use App\Services\PromotionService;
+
+class PromotionController extends Controller
+{
+    public function show(User $user, PromotionService $service)
+    {
+        $promotions = $service->getPromotionsForCustomer($user);
+
+        foreach ($promotions as $promotion) {
+            $user->notify(new PromotionNotification($promotion));
+        }
+
+        return response()->json(['promotions' => $promotions]);
+    }
+}

--- a/app/Models/CustomerPreference.php
+++ b/app/Models/CustomerPreference.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CustomerPreference extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'preference',
+        'value',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/PurchaseHistory.php
+++ b/app/Models/PurchaseHistory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PurchaseHistory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'item',
+        'quantity',
+        'price',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
 use Spatie\Translatable\HasTranslations;
 use App\Support\NotifiesWithLocale;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class User extends Authenticatable
 {
@@ -70,5 +71,15 @@ class User extends Authenticatable
     public function getPermissionsTeamId(): int|string|null
     {
         return $this->tenant_id;
+    }
+
+    public function purchaseHistories(): HasMany
+    {
+        return $this->hasMany(PurchaseHistory::class);
+    }
+
+    public function preferences(): HasMany
+    {
+        return $this->hasMany(CustomerPreference::class);
     }
 }

--- a/app/Notifications/PromotionNotification.php
+++ b/app/Notifications/PromotionNotification.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PromotionNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(public string $promotion)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage())->line($this->promotion);
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return ['promotion' => $this->promotion];
+    }
+}

--- a/app/Services/PromotionService.php
+++ b/app/Services/PromotionService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\PurchaseHistory;
+use App\Models\User;
+
+class PromotionService
+{
+    /**
+     * Determine promotions for the given customer.
+     *
+     * @return list<string>
+     */
+    public function getPromotionsForCustomer(User $user): array
+    {
+        $count = PurchaseHistory::where('user_id', $user->id)->count();
+
+        $promotions = [];
+
+        if ($count >= 5) {
+            $promotions[] = '10% off next purchase';
+        }
+
+        if ($count < 5) {
+            $promotions[] = 'Buy one get one free';
+        }
+
+        return $promotions;
+    }
+}

--- a/database/migrations/2026_01_01_000000_create_purchase_histories_table.php
+++ b/database/migrations/2026_01_01_000000_create_purchase_histories_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('purchase_histories', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('item');
+            $table->unsignedInteger('quantity');
+            $table->decimal('price', 8, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('purchase_histories');
+    }
+};

--- a/database/migrations/2026_01_01_000001_create_customer_preferences_table.php
+++ b/database/migrations/2026_01_01_000001_create_customer_preferences_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('customer_preferences', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('preference');
+            $table->string('value');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_preferences');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,10 +2,13 @@
 
 use Illuminate\Support\Facades\Route;
 use Nwidart\Modules\Facades\Module;
+use App\Http\Controllers\PromotionController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/promotions/{user}', [PromotionController::class, 'show']);
 
 if (Module::isEnabled('Pos')) {
         Route::middleware(['auth:sanctum', 'tenancy', 'role:owner'])->group(function () {


### PR DESCRIPTION
## Summary
- track purchases and customer preferences
- add promotion service with notification
- expose promotions endpoint

## Testing
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c0b93c2ac0833285920072d723de5b