### PR TITLE
Add payroll service with payout reporting

### DIFF
--- a/app/Services/PayrollService.php
+++ b/app/Services/PayrollService.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Attendance;
+use App\Support\CurrencyFormatter;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+
+class PayrollService
+{
+    /**
+     * Calculate total wages from a set of attendances and tips.
+     *
+     * @param  iterable<Attendance|array{clock_in:mixed,clock_out:mixed}>  $attendances
+     */
+    public function calculateWages(iterable $attendances, float $hourlyRate, float $tips = 0.0): float
+    {
+        $hours = $this->calculateHours($attendances);
+
+        return $hours * $hourlyRate + $tips;
+    }
+
+    /**
+     * Generate a payout report summarizing hours and wages.
+     *
+     * @param  iterable<Attendance|array{clock_in:mixed,clock_out:mixed}>  $attendances
+     * @return array{hours: float, wage: float, formatted_wage: string}
+     */
+    public function generatePayoutReport(iterable $attendances, float $hourlyRate, float $tips = 0.0): array
+    {
+        $hours = $this->calculateHours($attendances);
+        $wage = $hours * $hourlyRate + $tips;
+
+        return [
+            'hours' => $hours,
+            'wage' => $wage,
+            'formatted_wage' => CurrencyFormatter::format($wage),
+        ];
+    }
+
+    /**
+     * Export payout reports to a CSV string for accounting systems.
+     *
+     * @param  iterable<array{hours: float, wage: float}>  $reports
+     */
+    public function exportForAccounting(iterable $reports): string
+    {
+        $csv = "hours,wage\n";
+        foreach ($reports as $report) {
+            $csv .= $report['hours'] . ',' . $report['wage'] . "\n";
+        }
+
+        return $csv;
+    }
+
+    /**
+     * Calculate total hours from the provided attendances.
+     *
+     * @param  iterable<Attendance|array{clock_in:mixed,clock_out:mixed}>  $attendances
+     */
+    private function calculateHours(iterable $attendances): float
+    {
+        $hours = 0.0;
+        foreach ($attendances as $attendance) {
+            $clockIn = $attendance instanceof Attendance ? $attendance->clock_in : $attendance['clock_in'];
+            $clockOut = $attendance instanceof Attendance ? $attendance->clock_out : $attendance['clock_out'];
+
+            if (! $clockIn instanceof CarbonInterface) {
+                $clockIn = Carbon::parse($clockIn);
+            }
+
+            if (! $clockOut instanceof CarbonInterface) {
+                $clockOut = Carbon::parse($clockOut);
+            }
+
+            $hours += $clockOut->diffInMinutes($clockIn, true) / 60;
+        }
+
+        return $hours;
+    }
+}
+

--- a/tests/Unit/PayrollServiceTest.php
+++ b/tests/Unit/PayrollServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Support {
+    if (! function_exists(__NAMESPACE__ . '\\tenant')) {
+        function tenant($key = null) {
+            $tenant = \Tests\Unit\PayrollServiceTenantContext::$tenant;
+            if (! $tenant) {
+                return null;
+            }
+            return $key ? $tenant->{$key} : $tenant;
+        }
+    }
+}
+
+namespace Tests\Unit {
+
+use App\Models\Attendance;
+use App\Models\Tenant;
+use App\Services\PayrollService;
+use NumberFormatter;
+use Tests\TestCase;
+
+class PayrollServiceTenantContext
+{
+    public static ?Tenant $tenant = null;
+}
+
+class PayrollServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        PayrollServiceTenantContext::$tenant = null;
+        app()->forgetInstance('tenant');
+    }
+
+    public function test_calculates_wages_generates_report_and_exports_csv_with_tenant_currency(): void
+    {
+        $tenant = new Tenant(['id' => 1, 'currency' => 'EUR']);
+        PayrollServiceTenantContext::$tenant = $tenant;
+
+        $attendances = [
+            new Attendance(['clock_in' => '2024-01-01 08:00', 'clock_out' => '2024-01-01 12:00']),
+            new Attendance(['clock_in' => '2024-01-02 09:00', 'clock_out' => '2024-01-02 12:30']),
+        ];
+
+        $service = new PayrollService();
+        $report = $service->generatePayoutReport($attendances, 10, 5);
+
+        $this->assertSame(7.5, $report['hours']);
+        $this->assertSame(80.0, $report['wage']);
+
+        $formatter = new NumberFormatter(app()->getLocale(), NumberFormatter::CURRENCY);
+        $this->assertSame($formatter->formatCurrency(80, 'EUR'), $report['formatted_wage']);
+
+        $csv = $service->exportForAccounting([$report]);
+        $this->assertSame("hours,wage\n7.5,80\n", $csv);
+    }
+}
+
+}
+


### PR DESCRIPTION
## Summary
- add PayrollService to compute wages from attendance and tips
- format payout reports with tenant currency and export as CSV
- cover payroll calculations with unit test

## Testing
- `vendor/bin/phpunit tests/Unit/PayrollServiceTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c0d979e82083329e72ef6751a5ffe7