### PR TITLE
Add dashboard websocket module and analytics services

### DIFF
--- a/MODULES_OVERVIEW.md
+++ b/MODULES_OVERVIEW.md
@@ -108,40 +108,45 @@
 ---
 
 ## 📊 Reports & Monitoring
-### 14. **Reports**
-- **Filters**: By day, shift, hour, employee, item, customer.  
-- **Exports**: CSV, Excel, PDF.  
-- **Integration**: All transaction modules.  
+### 14. **Dashboard**
+- **Features**: Real-time KPI updates via WebSockets.
+- **Integration**: Aggregates metrics from all modules.
 
-### 15. **Notifications**
-- **Scope**: Manager, Waiter, Kitchen, Super Admin, SaaS staff.  
-- **Channels**: In-app, Email, SMS, Push.  
-- **Events**: Low stock, unpaid bill, table opened, subscription expiring.  
-- **Integration**: Global across modules.  
+### 15. **Reports**
+- **Filters**: By day, shift, hour, employee, item, customer.
+- **Exports**: CSV, Excel, PDF.
+- **Integration**: All transaction modules.
+- **Metrics**: Menu engineering (profitability, popularity) and financial forecasting.
+
+### 16. **Notifications**
+- **Scope**: Manager, Waiter, Kitchen, Super Admin, SaaS staff.
+- **Channels**: In-app, Email, SMS, Push.
+- **Events**: Low stock, unpaid bill, table opened, subscription expiring.
+- **Integration**: Global across modules.
 
 ---
 
 ## 🧩 Extra Modules
-### 16. **HR & Jobs**
+### 17. **HR & Jobs**
 - **Features**: Post jobs, apply, track candidates.  
 - **Database**: `jobs`, `applications`.  
 - **Integration**: Membership system.  
 
-### 17. **Restaurant Rentals**
+### 18. **Restaurant Rentals**
 - **Features**: Post restaurants/cafés for rent/sale.
 - **Database**: `listings`.
 - **Integration**: Membership system.
 
-### 18. **Equipment Maintenance**
+### 19. **Equipment Maintenance**
 - **Features**: Track kitchen/coffee equipment health, schedule maintenance.
 - **Database**: `equipment`, `maintenance_logs`.
 
-### 19. **Franchise Management**
+### 20. **Franchise Management**
 - **Features**: Manage and publish franchise opportunities.
 - **Database**: `franchises`.
 - **Integration**: Membership system.
 
-### 20. **Equipment Leasing**
+### 21. **Equipment Leasing**
 - **Features**: Lease hardware with payment schedules and inventory updates.
 - **Database**: `lease_contracts`.
 - **Integration**: Marketplace, Inventory.

--- a/Modules/Dashboard/app/Events/DashboardUpdated.php
+++ b/Modules/Dashboard/app/Events/DashboardUpdated.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\Dashboard\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DashboardUpdated implements ShouldBroadcast
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public array $data)
+    {
+    }
+
+    public function broadcastOn(): Channel
+    {
+        return new Channel('dashboard-updates');
+    }
+}

--- a/Modules/Dashboard/app/Providers/DashboardServiceProvider.php
+++ b/Modules/Dashboard/app/Providers/DashboardServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Modules\Dashboard\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class DashboardServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        //
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/Modules/Dashboard/app/Services/DashboardBroadcaster.php
+++ b/Modules/Dashboard/app/Services/DashboardBroadcaster.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Dashboard\Services;
+
+use Modules\Dashboard\Events\DashboardUpdated;
+
+class DashboardBroadcaster
+{
+    public function broadcast(array $data): void
+    {
+        DashboardUpdated::dispatch($data);
+    }
+}

--- a/Modules/Dashboard/composer.json
+++ b/Modules/Dashboard/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "nwidart/dashboard",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {}
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Dashboard\\": "app/",
+            "Modules\\Dashboard\\Database\\Factories\\": "database/factories/",
+            "Modules\\Dashboard\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Dashboard\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/Dashboard/module.json
+++ b/Modules/Dashboard/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "Dashboard",
+    "alias": "dashboard",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\Dashboard\\Providers\\DashboardServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/Dashboard/tests/Unit/DashboardBroadcasterTest.php
+++ b/Modules/Dashboard/tests/Unit/DashboardBroadcasterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Modules\Dashboard\Tests\Unit;
+
+use Illuminate\Support\Facades\Event;
+use Modules\Dashboard\Events\DashboardUpdated;
+use Modules\Dashboard\Services\DashboardBroadcaster;
+use Tests\TestCase;
+
+class DashboardBroadcasterTest extends TestCase
+{
+    public function test_broadcasts_dashboard_updates(): void
+    {
+        Event::fake();
+
+        $broadcaster = new DashboardBroadcaster();
+        $payload = ['sales' => 100];
+        $broadcaster->broadcast($payload);
+
+        Event::assertDispatched(DashboardUpdated::class, function ($event) use ($payload) {
+            return $event->data === $payload;
+        });
+    }
+}

--- a/Modules/Reports/app/Services/FinancialReportService.php
+++ b/Modules/Reports/app/Services/FinancialReportService.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Modules\Reports\Services;
+
+class FinancialReportService
+{
+    /**
+     * Generate aggregate financial report.
+     *
+     * @param array $transactions Each transaction contains revenue and cost.
+     */
+    public function generateReport(array $transactions): array
+    {
+        $totals = ['revenue' => 0, 'cost' => 0];
+
+        foreach ($transactions as $transaction) {
+            $totals['revenue'] += $transaction['revenue'];
+            $totals['cost'] += $transaction['cost'];
+        }
+
+        $totals['profit'] = $totals['revenue'] - $totals['cost'];
+
+        return $totals;
+    }
+
+    /**
+     * Forecast revenue using a simple moving average.
+     *
+     * @param array $monthlyRevenue Historical revenue values.
+     * @param int $months Number of months to forecast.
+     */
+    public function forecastRevenue(array $monthlyRevenue, int $months = 1): array
+    {
+        $forecast = [];
+        $data = $monthlyRevenue;
+
+        for ($i = 0; $i < $months; $i++) {
+            $average = array_sum($data) / count($data);
+            $forecast[] = $average;
+            $data[] = $average;
+            array_shift($data);
+        }
+
+        return $forecast;
+    }
+}

--- a/Modules/Reports/app/Services/MenuEngineeringService.php
+++ b/Modules/Reports/app/Services/MenuEngineeringService.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Modules\Reports\Services;
+
+class MenuEngineeringService
+{
+    /**
+     * Calculate profitability and popularity for menu items.
+     *
+     * @param array $items
+     * @return array
+     */
+    public function calculate(array $items): array
+    {
+        $totalSales = array_sum(array_column($items, 'sales'));
+
+        return array_map(function (array $item) use ($totalSales) {
+            $profitability = $item['price'] - $item['cost'];
+            $popularity = $totalSales > 0 ? $item['sales'] / $totalSales : 0;
+
+            return [
+                'name' => $item['name'],
+                'profitability' => $profitability,
+                'popularity' => $popularity,
+            ];
+        }, $items);
+    }
+}

--- a/Modules/Reports/tests/Unit/FinancialReportServiceTest.php
+++ b/Modules/Reports/tests/Unit/FinancialReportServiceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Modules\Reports\Tests\Unit;
+
+use Modules\Reports\Services\FinancialReportService;
+use Tests\TestCase;
+
+class FinancialReportServiceTest extends TestCase
+{
+    public function test_generates_report_and_forecast(): void
+    {
+        $service = new FinancialReportService();
+        $transactions = [
+            ['revenue' => 1000, 'cost' => 400],
+            ['revenue' => 1500, 'cost' => 500],
+        ];
+
+        $report = $service->generateReport($transactions);
+
+        $this->assertSame(2500, $report['revenue']);
+        $this->assertSame(900, $report['cost']);
+        $this->assertSame(1600, $report['profit']);
+
+        $forecast = $service->forecastRevenue([1000, 1200, 1300], 2);
+        $this->assertCount(2, $forecast);
+        $this->assertEqualsWithDelta(1166.6667, $forecast[0], 0.0001);
+    }
+}

--- a/Modules/Reports/tests/Unit/MenuEngineeringServiceTest.php
+++ b/Modules/Reports/tests/Unit/MenuEngineeringServiceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Modules\Reports\Tests\Unit;
+
+use Modules\Reports\Services\MenuEngineeringService;
+use Tests\TestCase;
+
+class MenuEngineeringServiceTest extends TestCase
+{
+    public function test_calculates_profitability_and_popularity(): void
+    {
+        $service = new MenuEngineeringService();
+        $items = [
+            ['name' => 'Coffee', 'price' => 5, 'cost' => 2, 'sales' => 100],
+            ['name' => 'Tea', 'price' => 3, 'cost' => 1, 'sales' => 50],
+        ];
+
+        $result = $service->calculate($items);
+
+        $this->assertCount(2, $result);
+        $this->assertEquals(3.0, $result[0]['profitability']);
+        $this->assertEqualsWithDelta(100/150, $result[0]['popularity'], 0.0001);
+    }
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -24,5 +24,6 @@
     "FoodSafety": false,
     "Training": true,
     "Franchise": false,
-    "EquipmentLeasing": false
+    "EquipmentLeasing": false,
+    "Dashboard": true
 }


### PR DESCRIPTION
## Summary
- add Dashboard module broadcasting updates over WebSockets
- implement menu engineering metrics and financial forecasting services
- document dashboard and reporting capabilities

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e50279e883328cdb75826872312e