### PR TITLE
chore: register missing modules

### DIFF
--- a/config/modules.php
+++ b/config/modules.php
@@ -16,12 +16,20 @@ return [
     'namespace' => 'Modules',
 
     'modules' => [
+        'ArVrMenu' => ['enabled' => false],
         'Billing' => ['enabled' => false],
         'Core' => ['enabled' => true],
         'Crm' => ['enabled' => true],
+        'Dashboard' => ['enabled' => true],
+        'EnergyTracking' => ['enabled' => false],
+        'EquipmentLeasing' => ['enabled' => false],
         'EquipmentMaintenance' => ['enabled' => true],
         'EquipmentMonitoring' => ['enabled' => true],
+        'EventManagement' => ['enabled' => false],
         'FloorPlanDesigner' => ['enabled' => false],
+        'FoodSafety' => ['enabled' => false],
+        'Franchise' => ['enabled' => false],
+        'HotelPms' => ['enabled' => false],
         'HrJobs' => ['enabled' => false],
         'Inventory' => ['enabled' => false],
         'Jobs' => ['enabled' => false],
@@ -35,7 +43,10 @@ return [
         'QrOrdering' => ['enabled' => true],
         'Rentals' => ['enabled' => false],
         'Reports' => ['enabled' => true],
+        'SelfServiceKiosk' => ['enabled' => true],
         'SuperAdmin' => ['enabled' => false],
+        'TableReservations' => ['enabled' => true],
+        'Training' => ['enabled' => true],
     ],
 
     /*


### PR DESCRIPTION
## Summary
- include all modules in config modules array
- set default enabled flags aligned with module statuses

## Testing
- `php artisan module:list`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ed78bf288332a5ae570fbf68010d