### PR TITLE
Add queue worker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 
 This application can be deployed using [Laravel Forge](https://forge.laravel.com) or a similar tool. The `production.yml` Docker configuration provides module-specific environment variables for configuring services during deployment.
 
+## Queue Worker
+
+Queued jobs are processed by a dedicated `queue-worker` service defined in the Docker configuration. Start it with:
+
+```bash
+docker compose up queue-worker
+```
+
+The service runs `php artisan queue:work` using the same PHP image as the main application.
+
 ## Module Scaffolding
 
 Generate a new module with migrations, models, bilingual translations, and tests via the Artisan command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,14 @@ services:
       REVERB_PORT: ${REVERB_PORT}
     ports:
       - "${REVERB_PORT:-8080}:8080"
+  queue-worker:
+    image: php:8.3-fpm
+    volumes:
+      - .:/var/www
+    depends_on:
+      - mysql
+      - redis
+    command: php artisan queue:work
   nginx:
     image: nginx:alpine
     ports:

--- a/production.yml
+++ b/production.yml
@@ -31,6 +31,18 @@ services:
       REVERB_PORT: ${REVERB_PORT}
     ports:
       - "${REVERB_PORT:-8080}:8080"
+  queue-worker:
+    image: php:8.3-fpm
+    volumes:
+      - .:/var/www
+    depends_on:
+      - mysql
+      - redis
+    environment:
+      POS_MODULE_ENABLED: ${POS_MODULE_ENABLED:-true}
+      INVENTORY_MODULE_ENABLED: ${INVENTORY_MODULE_ENABLED:-true}
+      CRM_MODULE_ENABLED: ${CRM_MODULE_ENABLED:-false}
+    command: php artisan queue:work
   nginx:
     image: nginx:alpine
     ports:


### PR DESCRIPTION
## Summary
- add queue-worker service to Docker configs to run `php artisan queue:work`
- document how to start the queue-worker

## Testing
- `composer test` *(fails: file_get_contents(/workspace/cafeos/.env): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fb75afdc8332b4b9011f322965a3