### PR TITLE
refactor: introduce TenantModel base

### DIFF
--- a/Modules/Crm/app/Models/Survey.php
+++ b/Modules/Crm/app/Models/Survey.php
@@ -2,13 +2,12 @@
 
 namespace Modules\Crm\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use App\Models\Concerns\BelongsToTenant;
 
-class Survey extends Model
+class Survey extends TenantModel
 {
-    use HasFactory, BelongsToTenant;
+    use HasFactory;
 
     protected $fillable = [
         'tenant_id',

--- a/Modules/Franchise/app/Models/Franchise.php
+++ b/Modules/Franchise/app/Models/Franchise.php
@@ -2,14 +2,13 @@
 
 namespace Modules\Franchise\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Spatie\Translatable\HasTranslations;
-use App\Models\Concerns\BelongsToTenant;
 
-class Franchise extends Model
+class Franchise extends TenantModel
 {
-    use HasFactory, HasTranslations, BelongsToTenant;
+    use HasFactory, HasTranslations;
 
     protected array $translatable = ['name', 'description'];
 

--- a/Modules/Inventory/app/Models/InventoryItem.php
+++ b/Modules/Inventory/app/Models/InventoryItem.php
@@ -2,13 +2,12 @@
 
 namespace Modules\Inventory\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use App\Models\Concerns\BelongsToTenant;
 
-class InventoryItem extends Model
+class InventoryItem extends TenantModel
 {
-    use HasFactory, BelongsToTenant;
+    use HasFactory;
 
     protected $fillable = [
         'tenant_id',

--- a/Modules/Inventory/app/Models/StockMovement.php
+++ b/Modules/Inventory/app/Models/StockMovement.php
@@ -2,13 +2,12 @@
 
 namespace Modules\Inventory\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use App\Models\Concerns\BelongsToTenant;
 
-class StockMovement extends Model
+class StockMovement extends TenantModel
 {
-    use HasFactory, BelongsToTenant;
+    use HasFactory;
 
     protected $fillable = [
         'tenant_id',

--- a/Modules/Notifications/app/Models/Notification.php
+++ b/Modules/Notifications/app/Models/Notification.php
@@ -2,13 +2,10 @@
 
 namespace Modules\Notifications\Models;
 
-use Illuminate\Database\Eloquent\Model;
-use App\Models\Concerns\BelongsToTenant;
+use App\Models\TenantModel;
 
-class Notification extends Model
+class Notification extends TenantModel
 {
-    use BelongsToTenant;
-
     protected $table = 'notifications_inbox';
 
     protected $fillable = [

--- a/app/Models/TenantModel.php
+++ b/app/Models/TenantModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\BelongsToTenant;
+use Illuminate\Database\Eloquent\Model;
+
+abstract class TenantModel extends Model
+{
+    use BelongsToTenant;
+}


### PR DESCRIPTION
## Summary
- add TenantModel base class using BelongsToTenant trait
- refactor inventory, franchise, CRM, and notification models to extend TenantModel

## Testing
- `vendor/bin/pint app/Models/TenantModel.php Modules/Inventory/app/Models/InventoryItem.php Modules/Inventory/app/Models/StockMovement.php Modules/Franchise/app/Models/Franchise.php Modules/Crm/app/Models/Survey.php Modules/Notifications/app/Models/Notification.php`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c1045fa32083329a71dd79084ade19