### PR TITLE
Add policies and Filament resources for Core models

### DIFF
--- a/Modules/Core/tests/Unit/PermissionPolicyTest.php
+++ b/Modules/Core/tests/Unit/PermissionPolicyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Modules\Core\Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\Core\Models\Permission;
+use Modules\Core\Models\Role;
+use Tests\TestCase;
+use Spatie\Permission\PermissionRegistrar;
+
+class PermissionPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_can_manage_permissions(): void
+    {
+        $superAdminRole = Role::create(['name' => 'Super Admin', 'guard_name' => 'web']);
+        $user = User::factory()->create();
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->setPermissionsTeamId($user->tenant_id);
+        $registrar->forgetCachedPermissions();
+        $user->assignRole($superAdminRole);
+        $permission = Permission::create(['name' => 'edit posts', 'guard_name' => 'web']);
+
+        $this->assertTrue($user->can('viewAny', Permission::class));
+        $this->assertTrue($user->can('view', $permission));
+        $this->assertTrue($user->can('create', Permission::class));
+        $this->assertTrue($user->can('update', $permission));
+        $this->assertTrue($user->can('delete', $permission));
+    }
+
+    public function test_non_admin_cannot_manage_permissions(): void
+    {
+        $permission = Permission::create(['name' => 'edit posts', 'guard_name' => 'web']);
+        $user = User::factory()->create();
+
+        $this->assertFalse($user->can('viewAny', Permission::class));
+        $this->assertFalse($user->can('view', $permission));
+        $this->assertFalse($user->can('create', Permission::class));
+        $this->assertFalse($user->can('update', $permission));
+        $this->assertFalse($user->can('delete', $permission));
+    }
+}

--- a/Modules/Core/tests/Unit/RolePolicyTest.php
+++ b/Modules/Core/tests/Unit/RolePolicyTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Modules\Core\Tests\Unit;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\Core\Models\Role;
+use Tests\TestCase;
+use Spatie\Permission\PermissionRegistrar;
+
+class RolePolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_can_manage_roles(): void
+    {
+        $superAdminRole = Role::create(['name' => 'Super Admin', 'guard_name' => 'web']);
+        $user = User::factory()->create();
+        $registrar = app(PermissionRegistrar::class);
+        $registrar->setPermissionsTeamId($user->tenant_id);
+        $registrar->forgetCachedPermissions();
+        $user->assignRole($superAdminRole);
+        $role = Role::create(['name' => 'Manager', 'guard_name' => 'web']);
+
+        $this->assertTrue($user->can('viewAny', Role::class));
+        $this->assertTrue($user->can('view', $role));
+        $this->assertTrue($user->can('create', Role::class));
+        $this->assertTrue($user->can('update', $role));
+        $this->assertTrue($user->can('delete', $role));
+    }
+
+    public function test_non_admin_cannot_manage_roles(): void
+    {
+        $role = Role::create(['name' => 'Manager']);
+        $user = User::factory()->create();
+
+        $this->assertFalse($user->can('viewAny', Role::class));
+        $this->assertFalse($user->can('view', $role));
+        $this->assertFalse($user->can('create', Role::class));
+        $this->assertFalse($user->can('update', $role));
+        $this->assertFalse($user->can('delete', $role));
+    }
+}

--- a/app/Filament/Resources/Modules/Core/Pages/CreatePermission.php
+++ b/app/Filament/Resources/Modules/Core/Pages/CreatePermission.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Modules\Core\Pages;
+
+use App\Filament\Resources\Modules\Core\PermissionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePermission extends CreateRecord
+{
+    protected static string $resource = PermissionResource::class;
+}

--- a/app/Filament/Resources/Modules/Core/Pages/CreateRole.php
+++ b/app/Filament/Resources/Modules/Core/Pages/CreateRole.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Modules\Core\Pages;
+
+use App\Filament\Resources\Modules\Core\RoleResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateRole extends CreateRecord
+{
+    protected static string $resource = RoleResource::class;
+}

--- a/app/Filament/Resources/Modules/Core/Pages/EditPermission.php
+++ b/app/Filament/Resources/Modules/Core/Pages/EditPermission.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Modules\Core\Pages;
+
+use App\Filament\Resources\Modules\Core\PermissionResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPermission extends EditRecord
+{
+    protected static string $resource = PermissionResource::class;
+}

--- a/app/Filament/Resources/Modules/Core/Pages/EditRole.php
+++ b/app/Filament/Resources/Modules/Core/Pages/EditRole.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Modules\Core\Pages;
+
+use App\Filament\Resources\Modules\Core\RoleResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditRole extends EditRecord
+{
+    protected static string $resource = RoleResource::class;
+}

--- a/app/Filament/Resources/Modules/Core/Pages/ListPermissions.php
+++ b/app/Filament/Resources/Modules/Core/Pages/ListPermissions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Modules\Core\Pages;
+
+use App\Filament\Resources\Modules\Core\PermissionResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPermissions extends ListRecords
+{
+    protected static string $resource = PermissionResource::class;
+}

--- a/app/Filament/Resources/Modules/Core/Pages/ListRoles.php
+++ b/app/Filament/Resources/Modules/Core/Pages/ListRoles.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Modules\Core\Pages;
+
+use App\Filament\Resources\Modules\Core\RoleResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRoles extends ListRecords
+{
+    protected static string $resource = RoleResource::class;
+}

--- a/app/Filament/Resources/Modules/Core/PermissionResource.php
+++ b/app/Filament/Resources/Modules/Core/PermissionResource.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Resources\Modules\Core;
+
+use App\Filament\Resources\Concerns\TenantScoped;
+use App\Filament\Resources\Modules\Core\Pages\CreatePermission;
+use App\Filament\Resources\Modules\Core\Pages\EditPermission;
+use App\Filament\Resources\Modules\Core\Pages\ListPermissions;
+use Modules\Core\Models\Permission;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class PermissionResource extends Resource
+{
+    use TenantScoped;
+
+    protected static ?string $model = Permission::class;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('name')->required(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListPermissions::route('/'),
+            'create' => CreatePermission::route('/create'),
+            'edit' => EditPermission::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Modules/Core/RoleResource.php
+++ b/app/Filament/Resources/Modules/Core/RoleResource.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Resources\Modules\Core;
+
+use App\Filament\Resources\Concerns\TenantScoped;
+use App\Filament\Resources\Modules\Core\Pages\CreateRole;
+use App\Filament\Resources\Modules\Core\Pages\EditRole;
+use App\Filament\Resources\Modules\Core\Pages\ListRoles;
+use Modules\Core\Models\Role;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class RoleResource extends Resource
+{
+    use TenantScoped;
+
+    protected static ?string $model = Role::class;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('name')->required(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListRoles::route('/'),
+            'create' => CreateRole::route('/create'),
+            'edit' => EditRole::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Policies/PermissionPolicy.php
+++ b/app/Policies/PermissionPolicy.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Modules\Core\Models\Permission;
+
+class PermissionPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Permission $permission): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Permission $permission): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Permission $permission): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Permission $permission): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Permission $permission): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+}

--- a/app/Policies/RolePolicy.php
+++ b/app/Policies/RolePolicy.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Modules\Core\Models\Role;
+
+class RolePolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Role $role): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Role $role): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Role $role): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Role $role): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Role $role): bool
+    {
+        return $user->hasRole('Super Admin');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use App\Models\Tenant;
+use Modules\Core\Models\Role;
+use Modules\Core\Models\Permission;
+use App\Policies\TenantPolicy;
+use App\Policies\RolePolicy;
+use App\Policies\PermissionPolicy;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * The policy mappings for the application.
+     *
+     * @var array<class-string, class-string>
+     */
+    protected $policies = [
+        Tenant::class => TenantPolicy::class,
+        Role::class => RolePolicy::class,
+        Permission::class => PermissionPolicy::class,
+    ];
+
+    /**
+     * Register any authentication / authorization services.
+     */
+    public function boot(): void
+    {
+        $this->registerPolicies();
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,6 +2,7 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
     App\Providers\Filament\AdminPanelProvider::class,
     App\Providers\ModuleServiceProvider::class,
     App\Providers\TelescopeServiceProvider::class,


### PR DESCRIPTION
## Summary
- add Role and Permission policies with Super Admin gate
- register policies via new AuthServiceProvider
- introduce Filament resources for managing Core roles and permissions
- cover policies with PHPUnit tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68c1064acadc83329ccece74c3127431