### PR TITLE
Enforce tenant scope in module models and migrations

### DIFF
--- a/Modules/Crm/app/Models/SurveyResponse.php
+++ b/Modules/Crm/app/Models/SurveyResponse.php
@@ -2,14 +2,15 @@
 
 namespace Modules\Crm\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
-class SurveyResponse extends Model
+class SurveyResponse extends TenantModel
 {
     use HasFactory;
 
     protected $fillable = [
+        'tenant_id',
         'survey_id',
         'branch_id',
         'rating',

--- a/Modules/Crm/app/Services/SurveyService.php
+++ b/Modules/Crm/app/Services/SurveyService.php
@@ -20,7 +20,10 @@ class SurveyService implements SurveyServiceInterface
 
     public function submitResponse(int $surveyId, int $branchId, int $rating, ?string $comment = null): SurveyResponse
     {
+        $survey = Survey::findOrFail($surveyId);
+
         $response = SurveyResponse::create([
+            'tenant_id' => $survey->tenant_id,
             'survey_id' => $surveyId,
             'branch_id' => $branchId,
             'rating' => $rating,

--- a/Modules/Crm/database/migrations/2024_01_01_000000_create_surveys_table.php
+++ b/Modules/Crm/database/migrations/2024_01_01_000000_create_surveys_table.php
@@ -13,6 +13,8 @@ return new class extends Migration {
             $table->unsignedBigInteger('branch_id');
             $table->string('question');
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/Crm/database/migrations/2024_01_01_000001_create_survey_responses_table.php
+++ b/Modules/Crm/database/migrations/2024_01_01_000001_create_survey_responses_table.php
@@ -9,11 +9,14 @@ return new class extends Migration {
     {
         Schema::create('survey_responses', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->unsignedBigInteger('survey_id');
             $table->unsignedBigInteger('branch_id');
             $table->unsignedTinyInteger('rating');
             $table->text('comment')->nullable();
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/EquipmentMonitoring/app/Models/Alert.php
+++ b/Modules/EquipmentMonitoring/app/Models/Alert.php
@@ -2,16 +2,17 @@
 
 namespace Modules\EquipmentMonitoring\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
-class Alert extends Model
+class Alert extends TenantModel
 {
     use HasFactory;
 
     public $timestamps = true;
 
     protected $fillable = [
+        'tenant_id',
         'device_id',
         'message',
     ];

--- a/Modules/EquipmentMonitoring/app/Models/Device.php
+++ b/Modules/EquipmentMonitoring/app/Models/Device.php
@@ -2,14 +2,15 @@
 
 namespace Modules\EquipmentMonitoring\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
-class Device extends Model
+class Device extends TenantModel
 {
     use HasFactory;
 
     protected $fillable = [
+        'tenant_id',
         'name',
         'location',
         'temperature_threshold',

--- a/Modules/EquipmentMonitoring/app/Models/Reading.php
+++ b/Modules/EquipmentMonitoring/app/Models/Reading.php
@@ -2,14 +2,15 @@
 
 namespace Modules\EquipmentMonitoring\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
-class Reading extends Model
+class Reading extends TenantModel
 {
     use HasFactory;
 
     protected $fillable = [
+        'tenant_id',
         'device_id',
         'temperature',
         'status',

--- a/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230000_create_devices_table.php
+++ b/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230000_create_devices_table.php
@@ -9,10 +9,13 @@ return new class extends Migration {
     {
         Schema::create('devices', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->string('name');
             $table->string('location')->nullable();
             $table->float('temperature_threshold');
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230010_create_readings_table.php
+++ b/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230010_create_readings_table.php
@@ -9,10 +9,13 @@ return new class extends Migration {
     {
         Schema::create('readings', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->foreignId('device_id')->constrained('devices')->cascadeOnDelete();
             $table->float('temperature')->nullable();
             $table->string('status');
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230020_create_alerts_table.php
+++ b/Modules/EquipmentMonitoring/database/migrations/2025_09_09_230020_create_alerts_table.php
@@ -9,9 +9,12 @@ return new class extends Migration {
     {
         Schema::create('alerts', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->foreignId('device_id')->constrained('devices')->cascadeOnDelete();
             $table->string('message');
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/FoodSafety/app/Models/IngredientInfo.php
+++ b/Modules/FoodSafety/app/Models/IngredientInfo.php
@@ -2,15 +2,16 @@
 
 namespace Modules\FoodSafety\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class IngredientInfo extends Model
+class IngredientInfo extends TenantModel
 {
     use HasFactory;
 
     protected $fillable = [
+        'tenant_id',
         'inventory_item_id',
         'expiry_date',
         'allergens',

--- a/Modules/FoodSafety/database/migrations/2024_01_01_000002_create_ingredient_infos_table.php
+++ b/Modules/FoodSafety/database/migrations/2024_01_01_000002_create_ingredient_infos_table.php
@@ -10,10 +10,13 @@ return new class extends Migration
     {
         Schema::create('ingredient_infos', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->unsignedBigInteger('inventory_item_id');
             $table->date('expiry_date')->nullable();
             $table->json('allergens')->nullable();
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/HrJobs/app/Models/Application.php
+++ b/Modules/HrJobs/app/Models/Application.php
@@ -2,12 +2,13 @@
 
 namespace Modules\HrJobs\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class Application extends Model
+class Application extends TenantModel
 {
     protected $fillable = [
+        'tenant_id',
         'job_id',
         'member_profile_id',
         'resume',

--- a/Modules/HrJobs/database/migrations/2024_01_01_100001_create_applications_table.php
+++ b/Modules/HrJobs/database/migrations/2024_01_01_100001_create_applications_table.php
@@ -10,12 +10,14 @@ return new class extends Migration
     {
         Schema::create('applications', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->foreignId('job_id')->constrained('hr_jobs')->cascadeOnDelete();
             $table->foreignId('member_profile_id')->constrained('member_profiles');
             $table->string('resume')->nullable();
             $table->string('status')->default('submitted');
             $table->timestamps();
             $table->index('job_id');
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/Jobs/app/Models/Job.php
+++ b/Modules/Jobs/app/Models/Job.php
@@ -2,10 +2,10 @@
 
 namespace Modules\Jobs\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Models\TenantModel;
 use Spatie\Translatable\HasTranslations;
 
-class Job extends Model
+class Job extends TenantModel
 {
     use HasTranslations;
 
@@ -15,4 +15,6 @@ class Job extends Model
      * @var list<string>
      */
     protected array $translatable = ['description'];
+
+    protected $fillable = ['tenant_id'];
 }

--- a/Modules/Kds/app/Models/KitchenStation.php
+++ b/Modules/Kds/app/Models/KitchenStation.php
@@ -2,14 +2,15 @@
 
 namespace Modules\Kds\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
-class KitchenStation extends Model
+class KitchenStation extends TenantModel
 {
     use HasFactory;
 
     protected $fillable = [
+        'tenant_id',
         'name',
     ];
 }

--- a/Modules/Kds/app/Models/KitchenTicket.php
+++ b/Modules/Kds/app/Models/KitchenTicket.php
@@ -2,14 +2,15 @@
 
 namespace Modules\Kds\Models;
 
+use App\Models\TenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
-class KitchenTicket extends Model
+class KitchenTicket extends TenantModel
 {
     use HasFactory;
 
     protected $fillable = [
+        'tenant_id',
         'order_id',
         'station_id',
         'status',

--- a/Modules/Kds/database/migrations/2025_09_09_100000_create_kitchen_stations_table.php
+++ b/Modules/Kds/database/migrations/2025_09_09_100000_create_kitchen_stations_table.php
@@ -9,8 +9,11 @@ return new class extends Migration {
     {
         Schema::create('kitchen_stations', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->string('name');
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/Kds/database/migrations/2025_09_09_100100_create_kitchen_tickets_table.php
+++ b/Modules/Kds/database/migrations/2025_09_09_100100_create_kitchen_tickets_table.php
@@ -9,11 +9,14 @@ return new class extends Migration {
     {
         Schema::create('kitchen_tickets', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->foreignId('order_id')->constrained('orders');
             $table->foreignId('station_id')->nullable()->constrained('kitchen_stations');
             $table->enum('status', ['pending', 'cooking', 'ready'])->default('pending');
             $table->boolean('approved')->default(false);
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/Marketplace/app/Models/Listing.php
+++ b/Modules/Marketplace/app/Models/Listing.php
@@ -2,12 +2,14 @@
 
 namespace Modules\Marketplace\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Models\TenantModel;
 use Spatie\Translatable\HasTranslations;
 
-class Listing extends Model
+class Listing extends TenantModel
 {
     use HasTranslations;
+
+    protected $fillable = ['tenant_id'];
 
     /**
      * The attributes that are translatable.

--- a/Modules/Procurement/app/Models/PurchaseOrder.php
+++ b/Modules/Procurement/app/Models/PurchaseOrder.php
@@ -2,11 +2,11 @@
 
 namespace Modules\Procurement\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Models\TenantModel;
 
-class PurchaseOrder extends Model
+class PurchaseOrder extends TenantModel
 {
-    protected $fillable = ['supplier_id', 'status', 'items'];
+    protected $fillable = ['tenant_id', 'supplier_id', 'status', 'items'];
 
     protected $casts = [
         'items' => 'array',

--- a/Modules/Procurement/app/Models/Supplier.php
+++ b/Modules/Procurement/app/Models/Supplier.php
@@ -2,10 +2,10 @@
 
 namespace Modules\Procurement\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Models\TenantModel;
 
-class Supplier extends Model
+class Supplier extends TenantModel
 {
-    protected $fillable = ['name', 'contact'];
+    protected $fillable = ['tenant_id', 'name', 'contact'];
 }
 

--- a/Modules/Procurement/database/migrations/2024_01_01_000000_create_suppliers_table.php
+++ b/Modules/Procurement/database/migrations/2024_01_01_000000_create_suppliers_table.php
@@ -9,9 +9,12 @@ return new class extends Migration {
     {
         Schema::create('suppliers', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->string('name');
             $table->string('contact')->nullable();
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/Procurement/database/migrations/2024_01_01_000001_create_purchase_orders_table.php
+++ b/Modules/Procurement/database/migrations/2024_01_01_000001_create_purchase_orders_table.php
@@ -9,10 +9,13 @@ return new class extends Migration {
     {
         Schema::create('purchase_orders', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->foreignId('supplier_id')->constrained('suppliers');
             $table->string('status')->default('pending');
             $table->json('items');
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/TableReservations/app/Models/Reservation.php
+++ b/Modules/TableReservations/app/Models/Reservation.php
@@ -2,11 +2,11 @@
 
 namespace Modules\TableReservations\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Models\TenantModel;
 
-class Reservation extends Model
+class Reservation extends TenantModel
 {
-    protected $fillable = ['table_id', 'customer_name', 'phone', 'reservation_time', 'status'];
+    protected $fillable = ['tenant_id', 'table_id', 'customer_name', 'phone', 'reservation_time', 'status'];
 
     public function table()
     {

--- a/Modules/TableReservations/app/Models/Table.php
+++ b/Modules/TableReservations/app/Models/Table.php
@@ -2,11 +2,11 @@
 
 namespace Modules\TableReservations\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Models\TenantModel;
 
-class Table extends Model
+class Table extends TenantModel
 {
-    protected $fillable = ['name', 'seats', 'status'];
+    protected $fillable = ['tenant_id', 'name', 'seats', 'status'];
 
     public function reservations()
     {

--- a/Modules/TableReservations/app/Models/WaitlistEntry.php
+++ b/Modules/TableReservations/app/Models/WaitlistEntry.php
@@ -2,12 +2,12 @@
 
 namespace Modules\TableReservations\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Models\TenantModel;
 use Modules\Membership\Enums\MembershipTier;
 
-class WaitlistEntry extends Model
+class WaitlistEntry extends TenantModel
 {
-    protected $fillable = ['customer_name', 'phone', 'party_size', 'status', 'membership_tier'];
+    protected $fillable = ['tenant_id', 'customer_name', 'phone', 'party_size', 'status', 'membership_tier'];
 
     protected $casts = [
         'membership_tier' => MembershipTier::class,

--- a/Modules/TableReservations/database/migrations/2024_01_01_000000_create_tables_table.php
+++ b/Modules/TableReservations/database/migrations/2024_01_01_000000_create_tables_table.php
@@ -9,10 +9,13 @@ return new class extends Migration {
     {
         Schema::create('tables', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->string('name');
             $table->integer('seats');
             $table->string('status');
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/TableReservations/database/migrations/2024_01_01_000001_create_reservations_table.php
+++ b/Modules/TableReservations/database/migrations/2024_01_01_000001_create_reservations_table.php
@@ -9,12 +9,15 @@ return new class extends Migration {
     {
         Schema::create('reservations', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->foreignId('table_id')->constrained('tables')->onDelete('cascade');
             $table->string('customer_name');
             $table->string('phone');
             $table->timestamp('reservation_time');
             $table->string('status');
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 

--- a/Modules/TableReservations/database/migrations/2024_01_01_000002_create_waitlist_entries_table.php
+++ b/Modules/TableReservations/database/migrations/2024_01_01_000002_create_waitlist_entries_table.php
@@ -9,11 +9,14 @@ return new class extends Migration {
     {
         Schema::create('waitlist_entries', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('tenant_id');
             $table->string('customer_name');
             $table->string('phone');
             $table->integer('party_size');
             $table->string('status');
             $table->timestamps();
+
+            $table->index('tenant_id');
         });
     }
 


### PR DESCRIPTION
## Summary
- make WaitlistEntry, Reservation, and many other module models extend `TenantModel`
- add `tenant_id` columns and indexes to tenant-aware module migrations
- ensure SurveyService sets tenant when creating survey responses

## Testing
- `composer test` *(fails: No code coverage driver available)*
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68c10c42f2588332bb07fa24ae935c72