### PR TITLE
Add tenant module feature flags and middleware

### DIFF
--- a/Modules/SuperAdmin/app/Http/Controllers/ModuleController.php
+++ b/Modules/SuperAdmin/app/Http/Controllers/ModuleController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Modules\SuperAdmin\Http\Controllers;
+
+use App\Models\TenantModule;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class ModuleController extends Controller
+{
+    public function index()
+    {
+        return response()->json(TenantModule::all());
+    }
+
+    public function update(Request $request, string $module)
+    {
+        $tenantModule = TenantModule::where('module', $module)->firstOrFail();
+        $tenantModule->update(['enabled' => $request->boolean('enabled')]);
+
+        return response()->json($tenantModule);
+    }
+}

--- a/Modules/SuperAdmin/routes/api.php
+++ b/Modules/SuperAdmin/routes/api.php
@@ -3,8 +3,11 @@
 use Illuminate\Support\Facades\Route;
 use Modules\Billing\Http\Controllers\PlanController;
 use Modules\Billing\Http\Controllers\SubscriptionController;
+use Modules\SuperAdmin\Http\Controllers\ModuleController;
 
 Route::middleware(['auth:sanctum'])->prefix('v1/super-admin')->group(function () {
     Route::get('plans', [PlanController::class, 'index'])->name('superadmin.plans.index');
     Route::get('subscriptions', [SubscriptionController::class, 'index'])->name('superadmin.subscriptions.index');
+    Route::get('modules', [ModuleController::class, 'index'])->name('superadmin.modules.index');
+    Route::patch('modules/{module}', [ModuleController::class, 'update'])->name('superadmin.modules.update');
 });

--- a/app/Http/Middleware/EnsureModuleEnabled.php
+++ b/app/Http/Middleware/EnsureModuleEnabled.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureModuleEnabled
+{
+    public function handle(Request $request, Closure $next, string $module): Response
+    {
+        if (! features()->enabled($module)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/TenantModule.php
+++ b/app/Models/TenantModule.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class TenantModule extends TenantModel
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'module',
+        'enabled',
+        'version',
+        'constraints',
+    ];
+
+    protected $casts = [
+        'enabled' => 'bool',
+        'constraints' => 'array',
+    ];
+}

--- a/app/Support/Features.php
+++ b/app/Support/Features.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\TenantModule;
+use Illuminate\Support\Facades\Cache;
+
+class Features
+{
+    public function enabled(string $module): bool
+    {
+        $tenantId = tenant('id');
+
+        if (!$tenantId) {
+            return false;
+        }
+
+        return Cache::remember("features.{$tenantId}.{$module}", 60, function () use ($tenantId, $module) {
+            return TenantModule::where('tenant_id', $tenantId)
+                ->where('module', $module)
+                ->value('enabled') ?? false;
+        });
+    }
+}
+
+if (! function_exists('features')) {
+    function features(): Features
+    {
+        return app(Features::class);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,7 @@ use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use App\Http\Middleware\InitializeTenancyByDomain;
 use App\Http\Middleware\SetUserLocale;
+use App\Http\Middleware\EnsureModuleEnabled;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -15,6 +16,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([
             'tenancy' => InitializeTenancyByDomain::class,
+            'module' => EnsureModuleEnabled::class,
         ]);
         $middleware->append(SetUserLocale::class);
     })

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/Support/Features.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/database/migrations/2024_04_01_000000_create_tenant_modules_table.php
+++ b/database/migrations/2024_04_01_000000_create_tenant_modules_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tenant_modules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->index();
+            $table->string('module');
+            $table->boolean('enabled')->default(false);
+            $table->string('version')->nullable();
+            $table->json('constraints')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+            $table->unique(['tenant_id', 'module']);
+            $table->index(['tenant_id', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tenant_modules');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call(RolesAndPermissionsSeeder::class);
+        $this->call([
+            RolesAndPermissionsSeeder::class,
+            TenantModulesSeeder::class,
+        ]);
 
         User::factory()->create([
             'name' => [

--- a/database/seeders/TenantModulesSeeder.php
+++ b/database/seeders/TenantModulesSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\TenantModule;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\File;
+
+class TenantModulesSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $statusPath = base_path('modules_statuses.json');
+        $statuses = File::exists($statusPath) ? json_decode(File::get($statusPath), true) : [];
+
+        foreach ($statuses as $module => $enabled) {
+            TenantModule::updateOrCreate(
+                ['module' => $module, 'tenant_id' => tenant('id')],
+                ['enabled' => $enabled]
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tenant_modules migration and seeder for default module flags
- expose feature flag helper with middleware and routing support
- allow SuperAdmin API to list and toggle tenant modules

## Testing
- `composer install --no-progress --no-scripts`
- `composer test` *(fails: Script @php artisan test handling the test event returned with error code 1; output shows 67 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c10fbbd270833287f421a5dc5bc68f