### PR TITLE
Add observability endpoints and runbooks

### DIFF
--- a/app/Http/Controllers/HealthController.php
+++ b/app/Http/Controllers/HealthController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Redis;
+
+class HealthController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        $checks = [];
+
+        $checks['database'] = rescue(fn () => DB::connection()->getPdo(), false, false) !== false;
+        $checks['queue'] = rescue(fn () => Redis::connection()->ping(), false, false) !== false;
+
+        $wsUrl = config('services.ws.health_url');
+        $checks['ws'] = $wsUrl ? rescue(fn () => Http::get($wsUrl)->ok(), false, false) : true;
+
+        $heartbeat = Cache::get('scheduler:heartbeat');
+        $checks['scheduler'] = $heartbeat && now()->diffInSeconds($heartbeat) < 300;
+
+        $status = collect($checks)->every(fn ($value) => $value) ? 'ok' : 'degraded';
+
+        return response()->json([
+            'status' => $status,
+            'checks' => $checks,
+        ]);
+    }
+}
+

--- a/app/Http/Controllers/MetricsController.php
+++ b/app/Http/Controllers/MetricsController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Prometheus\CollectorRegistry;
+use Prometheus\RenderTextFormat;
+use Symfony\Component\HttpFoundation\Response;
+
+class MetricsController extends Controller
+{
+    public function __invoke(): Response
+    {
+        $renderer = new RenderTextFormat();
+        $metrics = $renderer->render(
+            CollectorRegistry::getDefault()->getMetricFamilySamples()
+        );
+
+        return response($metrics, 200, ['Content-Type' => RenderTextFormat::MIME_TYPE]);
+    }
+}
+

--- a/app/Http/Middleware/PrometheusMetricsMiddleware.php
+++ b/app/Http/Middleware/PrometheusMetricsMiddleware.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Prometheus\CollectorRegistry;
+use Prometheus\Histogram;
+use Prometheus\Storage\InMemory;
+use Prometheus\Storage\Redis as RedisStorage;
+use Symfony\Component\HttpFoundation\Response;
+
+class PrometheusMetricsMiddleware
+{
+    private ?CollectorRegistry $registry = null;
+
+    private function registry(): CollectorRegistry
+    {
+        if ($this->registry !== null) {
+            return $this->registry;
+        }
+
+        if (extension_loaded('redis')) {
+            $config = config('database.redis.default');
+            $adapter = new RedisStorage([
+                'host' => $config['host'] ?? '127.0.0.1',
+                'port' => $config['port'] ?? 6379,
+                'password' => $config['password'] ?? null,
+                'database' => $config['database'] ?? 0,
+            ]);
+        } else {
+            $adapter = new InMemory();
+        }
+
+        return $this->registry = new CollectorRegistry($adapter);
+    }
+
+    public function handle($request, Closure $next)
+    {
+        $registry = $this->registry();
+
+        $counter = $registry->getOrRegisterCounter(
+            'app',
+            'http_requests_total',
+            'HTTP request count',
+            ['method', 'path', 'status']
+        );
+
+        $histogram = $registry->getOrRegisterHistogram(
+            'app',
+            'http_request_duration_seconds',
+            'HTTP request duration',
+            ['method', 'path', 'status']
+        );
+
+        $start = microtime(true);
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        $labels = [
+            $request->getMethod(),
+            $request->route()?->uri() ?? 'unknown',
+            (string) $response->getStatusCode(),
+        ];
+
+        $counter->inc($labels);
+        $histogram->observe(microtime(true) - $start, $labels);
+
+        return $response;
+    }
+}
+

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,7 @@ use App\Http\Middleware\EnsureModuleEnabled;
 use App\Http\Middleware\InitializeTenancyByDomain;
 use App\Http\Middleware\SetSecurityHeaders;
 use App\Http\Middleware\SetUserLocale;
+use App\Http\Middleware\PrometheusMetricsMiddleware;
 use App\Providers\ModuleServiceProvider;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -26,6 +27,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'module' => EnsureModuleEnabled::class,
             'webhook.signed' => AuditWebhookSignature::class,
         ]);
+        $middleware->append(PrometheusMetricsMiddleware::class);
         $middleware->append(SetUserLocale::class);
         $middleware->append(SetSecurityHeaders::class);
     })

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "nwidart/laravel-modules": "^12.0",
         "owen-it/laravel-auditing": "^14.0",
         "predis/predis": "^3.2",
+        "promphp/prometheus_client_php": "^2.10",
         "pusher/pusher-php-server": "^7.2",
         "spatie/laravel-permission": "^6.21",
         "spatie/laravel-translatable": "^6.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55cb7c2b6d0858ad7bf10feda3b7f765",
+    "content-hash": "4166696840de1922312a70ac1a835001",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -5078,6 +5078,74 @@
                 }
             ],
             "time": "2025-08-06T06:41:24+00:00"
+        },
+        {
+            "name": "promphp/prometheus_client_php",
+            "version": "v2.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PromPHP/prometheus_client_php.git",
+                "reference": "a283aea8269287dc35313a0055480d950c59ac1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PromPHP/prometheus_client_php/zipball/a283aea8269287dc35313a0055480d950c59ac1f",
+                "reference": "a283aea8269287dc35313a0055480d950c59ac1f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "endclothing/prometheus_client_php": "*",
+                "jimdo/prometheus_client_php": "*",
+                "lkaemmerling/prometheus_client_php": "*"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5.4",
+                "phpstan/phpstan-phpunit": "^1.1.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.4",
+                "squizlabs/php_codesniffer": "^3.6",
+                "symfony/polyfill-apcu": "^1.6"
+            },
+            "suggest": {
+                "ext-apc": "Required if using APCu.",
+                "ext-pdo": "Required if using PDO.",
+                "ext-redis": "Required if using Redis.",
+                "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway.",
+                "symfony/polyfill-apcu": "Required if you use APCu on PHP8.0+"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prometheus\\": "src/Prometheus/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Lukas Kämmerling",
+                    "email": "kontakt@lukas-kaemmerling.de"
+                }
+            ],
+            "description": "Prometheus instrumentation library for PHP applications.",
+            "support": {
+                "issues": "https://github.com/PromPHP/prometheus_client_php/issues",
+                "source": "https://github.com/PromPHP/prometheus_client_php/tree/v2.14.1"
+            },
+            "time": "2025-04-14T07:59:43+00:00"
         },
         {
             "name": "psr/clock",

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'dsn' => env('SENTRY_DSN'),
+    'release' => env('SENTRY_RELEASE'),
+    'environment' => env('SENTRY_ENVIRONMENT', env('APP_ENV')),
+    'traces_sample_rate' => (float) env('SENTRY_TRACES_SAMPLE_RATE', 0.0),
+    'profiles_sample_rate' => (float) env('SENTRY_PROFILES_SAMPLE_RATE', 0.0),
+];
+

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,8 @@ return [
         ],
     ],
 
+    'ws' => [
+        'health_url' => env('WS_HEALTH_URL'),
+    ],
+
 ];

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1,0 +1,22 @@
+# Runbooks
+
+## Database Connection Failures
+1. Check environment variables `DB_HOST`, `DB_PORT`, and credentials.
+2. Verify the database service is running and reachable.
+3. Review logs for connection errors.
+
+## Queue Backlog
+1. Inspect queue metrics via `/metrics` and Horizon dashboard.
+2. Ensure workers are running: `php artisan queue:work` or supervisor.
+3. Scale workers or investigate failing jobs.
+
+## WebSocket Outages
+1. Check Reverb/Pusher health at the configured `WS_HEALTH_URL`.
+2. Restart the websocket service if unresponsive.
+3. Validate network rules and credentials.
+
+## Scheduler Stalled
+1. Confirm `php artisan schedule:run` is executing via cron.
+2. Check `scheduler:heartbeat` cache key via `/health`.
+3. Review scheduler logs for exceptions.
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,12 +4,17 @@ use App\Http\Controllers\Auth\MfaController;
 use App\Http\Controllers\DriverLocationController;
 use App\Http\Controllers\PromotionController;
 use App\Http\Controllers\ShiftController;
+use App\Http\Controllers\MetricsController;
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 use Nwidart\Modules\Facades\Module;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/metrics', MetricsController::class);
+Route::get('/health', HealthController::class);
 
 Route::get('/promotions/{user}', [PromotionController::class, 'show']);
 


### PR DESCRIPTION
## Summary
- configure Sentry with environment-driven settings
- expose Prometheus metrics and global middleware
- add `/health` endpoint for DB/queue/WS/scheduler checks
- document runbooks for common operational failures

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=1G`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a94557388332839d6c81b5676383