### PR TITLE
feat: add blue-green deploy scripts and guarded migrations

### DIFF
--- a/database/.gitignore
+++ b/database/.gitignore
@@ -1,1 +1,2 @@
 *.sqlite*
+!database.sqlite

--- a/database/migrations/2024_03_01_000000_create_purchase_histories_table.php
+++ b/database/migrations/2024_03_01_000000_create_purchase_histories_table.php
@@ -8,6 +8,10 @@ return new class extends Migration
 {
     public function up(): void
     {
+        if (! env('INVENTORY_MODULE_ENABLED', false)) {
+            return;
+        }
+
         Schema::create('purchase_histories', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2024_03_01_000001_create_customer_preferences_table.php
+++ b/database/migrations/2024_03_01_000001_create_customer_preferences_table.php
@@ -8,6 +8,10 @@ return new class extends Migration
 {
     public function up(): void
     {
+        if (! env('CRM_MODULE_ENABLED', false)) {
+            return;
+        }
+
         Schema::create('customer_preferences', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2024_03_01_000002_create_shifts_table.php
+++ b/database/migrations/2024_03_01_000002_create_shifts_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (! env('POS_MODULE_ENABLED', true)) {
+            return;
+        }
+
         Schema::create('shifts', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2024_03_01_000003_create_attendances_table.php
+++ b/database/migrations/2024_03_01_000003_create_attendances_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (! env('POS_MODULE_ENABLED', true)) {
+            return;
+        }
+
         Schema::create('attendances', function (Blueprint $table) {
             $table->id();
             $table->foreignId('shift_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2024_03_01_000004_create_driver_locations_table.php
+++ b/database/migrations/2024_03_01_000004_create_driver_locations_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (! env('POS_MODULE_ENABLED', true)) {
+            return;
+        }
+
         Schema::create('driver_locations', function (Blueprint $table) {
             $table->id();
             $table->foreignId('driver_id')->constrained('users');

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -1,0 +1,16 @@
+# Release Playbook
+
+## Pre-deploy
+- Verify new database migrations have matching `down` methods.
+- Guard schema changes with appropriate feature flags (e.g. `POS_MODULE_ENABLED`).
+- Toggle features for target tenants prior to rollout.
+
+## Deploy
+- Execute `scripts/deploy.sh` to perform a blue/green deployment.
+- The script provisions the inactive stack and runs `scripts/smoke_test.sh` against `/health` and `/metrics`.
+- On success, route traffic to the new stack; on failure the script rolls back automatically.
+
+## Post-deploy
+- Monitor application metrics and health checks.
+- Keep the previous stack running until confidence is high, then tear it down.
+- Re-enable feature flags if rollback occurs.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+STACK="cafeos"
+ACTIVE_COLOR=$(cat CURRENT_COLOR 2>/dev/null || echo blue)
+if [ "$ACTIVE_COLOR" = "blue" ]; then
+  NEW_COLOR="green"
+else
+  NEW_COLOR="blue"
+fi
+
+echo "Deploying ${NEW_COLOR} stack..."
+
+docker compose -p "${STACK}-${NEW_COLOR}" -f production.yml up -d --build
+
+if ./scripts/smoke_test.sh "http://localhost"; then
+  echo "${NEW_COLOR}" > CURRENT_COLOR
+  echo "Deployment succeeded. Switch traffic to ${NEW_COLOR}."
+else
+  echo "Smoke tests failed. Rolling back ${NEW_COLOR} stack." >&2
+  docker compose -p "${STACK}-${NEW_COLOR}" -f production.yml down
+  exit 1
+fi

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+BASE_URL="${1:-http://localhost}"
+
+curl -fsS "$BASE_URL/health" >/dev/null
+curl -fsS "$BASE_URL/metrics" >/dev/null
+
+echo "Smoke tests passed."

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,17 +22,11 @@ abstract class TestCase extends BaseTestCase
 
         $this->baseRefreshDatabase();
 
-        static $migrated = [];
-
         foreach (Module::allEnabled() as $module) {
-            if (! in_array($module->getName(), $migrated, true)) {
-                Artisan::call('migrate', [
-                    '--path' => $module->getPath().'/database/migrations',
-                    '--realpath' => true,
-                ]);
-
-                $migrated[] = $module->getName();
-            }
+            Artisan::call('migrate', [
+                '--path' => $module->getPath().'/database/migrations',
+                '--realpath' => true,
+            ]);
 
             $module->boot();
         }


### PR DESCRIPTION
## Summary
- add blue/green deployment script with smoke tests
- guard migrations with module feature flags
- document release playbook for safe deploys

## Testing
- `vendor/bin/pint --test`
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68c1bca714fc8332978723bfd5defbd7