### PR TITLE
Add tenant export/delete commands and audit tracking

### DIFF
--- a/app/Console/Commands/TenantDelete.php
+++ b/app/Console/Commands/TenantDelete.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\AuditRequest;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class TenantDelete extends Command
+{
+    /** @var string */
+    protected $signature = 'tenant:delete {tenant_id}';
+
+    /** @var string */
+    protected $description = 'Delete all data for a tenant';
+
+    public function handle(): int
+    {
+        $tenantId = (int) $this->argument('tenant_id');
+
+        $tables = $this->tablesWithTenantId();
+        foreach ($tables as $table) {
+            DB::table($table)->where('tenant_id', $tenantId)->delete();
+        }
+
+        AuditRequest::create([
+            'tenant_id' => $tenantId,
+            'action' => 'delete',
+            'status' => 'completed',
+            'requested_at' => Carbon::now(),
+            'processed_at' => Carbon::now(),
+            'expires_at' => Carbon::now()->addDays(30),
+        ]);
+
+        $this->info("Tenant {$tenantId} data deleted");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Get tables that contain a tenant_id column.
+     *
+     * @return array<int, string>
+     */
+    protected function tablesWithTenantId(): array
+    {
+        $connection = DB::connection();
+        $driver = $connection->getDriverName();
+        $tables = [];
+
+        if ($driver === 'mysql') {
+            $result = $connection->select('SHOW TABLES');
+            $tables = array_map(fn ($row) => array_values((array) $row)[0], $result);
+        } elseif ($driver === 'sqlite') {
+            $result = $connection->select("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'");
+            $tables = array_map(fn ($row) => $row->name, $result);
+        }
+
+        return array_filter($tables, fn ($table) => Schema::hasColumn($table, 'tenant_id'));
+    }
+}

--- a/app/Console/Commands/TenantExport.php
+++ b/app/Console/Commands/TenantExport.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\AuditRequest;
+use App\Support\Backup\Anonymizer;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class TenantExport extends Command
+{
+    /** @var string */
+    protected $signature = 'tenant:export {tenant_id} {--path=}';
+
+    /** @var string */
+    protected $description = 'Export tenant data with anonymized sensitive fields';
+
+    public function handle(Anonymizer $anonymizer): int
+    {
+        $tenantId = (int) $this->argument('tenant_id');
+        $path = $this->option('path') ?? storage_path("exports/tenant-{$tenantId}.json");
+
+        $tables = $this->tablesWithTenantId();
+
+        $export = [];
+        foreach ($tables as $table) {
+            $rows = DB::table($table)
+                ->where('tenant_id', $tenantId)
+                ->get()
+                ->map(fn ($row) => $anonymizer->anonymize((array) $row))
+                ->toArray();
+
+            if ($rows) {
+                $export[$table] = $rows;
+            }
+        }
+
+        if (! is_dir(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+        file_put_contents($path, json_encode($export, JSON_PRETTY_PRINT));
+
+        AuditRequest::create([
+            'tenant_id' => $tenantId,
+            'action' => 'export',
+            'status' => 'completed',
+            'requested_at' => Carbon::now(),
+            'processed_at' => Carbon::now(),
+            'expires_at' => Carbon::now()->addDays(30),
+        ]);
+
+        $this->info("Tenant {$tenantId} export written to {$path}");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Get tables that contain a tenant_id column.
+     *
+     * @return array<int, string>
+     */
+    protected function tablesWithTenantId(): array
+    {
+        $connection = DB::connection();
+        $driver = $connection->getDriverName();
+        $tables = [];
+
+        if ($driver === 'mysql') {
+            $result = $connection->select('SHOW TABLES');
+            $tables = array_map(fn ($row) => array_values((array) $row)[0], $result);
+        } elseif ($driver === 'sqlite') {
+            $result = $connection->select("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'");
+            $tables = array_map(fn ($row) => $row->name, $result);
+        }
+
+        return array_filter($tables, fn ($table) => Schema::hasColumn($table, 'tenant_id'));
+    }
+}

--- a/app/Models/AuditRequest.php
+++ b/app/Models/AuditRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AuditRequest extends Model
+{
+    protected $fillable = [
+        'tenant_id',
+        'action',
+        'status',
+        'requested_at',
+        'processed_at',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'requested_at' => 'datetime',
+        'processed_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
+}

--- a/app/Support/Backup/Anonymizer.php
+++ b/app/Support/Backup/Anonymizer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Support\Backup;
+
+use Illuminate\Support\Str;
+
+class Anonymizer
+{
+    /**
+     * Fields considered sensitive and should be anonymized in backups.
+     *
+     * @var array<int, string>
+     */
+    protected array $fields = [
+        'name',
+        'first_name',
+        'last_name',
+        'email',
+        'phone',
+        'address',
+    ];
+
+    /**
+     * Anonymize sensitive fields for a single record.
+     *
+     * @param array<string, mixed> $record
+     * @return array<string, mixed>
+     */
+    public function anonymize(array $record): array
+    {
+        foreach ($this->fields as $field) {
+            if (! isset($record[$field])) {
+                continue;
+            }
+
+            if ($field === 'email') {
+                $record[$field] = Str::random(10).'@example.com';
+                continue;
+            }
+
+            $record[$field] = Str::random(10);
+        }
+
+        return $record;
+    }
+}

--- a/database/migrations/2024_05_27_000000_create_audit_requests_table.php
+++ b/database/migrations/2024_05_27_000000_create_audit_requests_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->index();
+            $table->string('action');
+            $table->string('status')->default('pending');
+            $table->timestamp('requested_at')->useCurrent();
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['tenant_id', 'status', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_requests');
+    }
+};

--- a/resources/views/legal/cookie-consent.blade.php
+++ b/resources/views/legal/cookie-consent.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">Cookie Consent</h1>
+    <p>We use cookies to improve your experience. By continuing to use CafeOS, you agree to our cookie policy.</p>
+</div>
+@endsection

--- a/resources/views/legal/dpa.blade.php
+++ b/resources/views/legal/dpa.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">Data Processing Agreement</h1>
+    <p>This template outlines how CafeOS processes personal data on behalf of tenants. Customize to reflect your jurisdiction and policies.</p>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- add tenant:export and tenant:delete artisan commands
- anonymize sensitive fields during exports
- record export/delete actions in audit_requests table
- add DPA and cookie consent templates

## Testing
- `CACHE_STORE=redis php artisan test` *(fails: BadMethodCallException: This cache store does not support tagging)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f34572d483328554ccd39e1e2f7f