### PR TITLE
feat: register module service providers

### DIFF
--- a/Modules/ArVrMenu/Providers/ArVrMenuServiceProvider.php
+++ b/Modules/ArVrMenu/Providers/ArVrMenuServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\ArVrMenu\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class ArVrMenuServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'arvrmenu');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'arvrmenu');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'arvrmenu');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'arvrmenu');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\ArVrMenu\\View\\Components', 'arvrmenu');
+    }
+}

--- a/Modules/ArVrMenu/composer.json
+++ b/Modules/ArVrMenu/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\ArVrMenu\\Providers\\ArVrMenuServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\ArVrMenu\\": "app/",
             "Modules\\ArVrMenu\\Database\\Factories\\": "database/factories/",
-            "Modules\\ArVrMenu\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\ArVrMenu\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\ArVrMenu\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Billing/Providers/BillingServiceProvider.php
+++ b/Modules/Billing/Providers/BillingServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Billing\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class BillingServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'billing');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'billing');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'billing');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'billing');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Billing\\View\\Components', 'billing');
+    }
+}

--- a/Modules/Billing/composer.json
+++ b/Modules/Billing/composer.json
@@ -9,17 +9,18 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
-            "aliases": {
-
-            }
+            "providers": [
+                "Modules\\Billing\\Providers\\BillingServiceProvider"
+            ],
+            "aliases": {}
         }
     },
     "autoload": {
         "psr-4": {
             "Modules\\Billing\\": "app/",
             "Modules\\Billing\\Database\\Factories\\": "database/factories/",
-            "Modules\\Billing\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Billing\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Billing\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Core/Providers/CoreServiceProvider.php
+++ b/Modules/Core/Providers/CoreServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Core\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class CoreServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'core');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'core');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'core');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'core');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Core\\View\\Components', 'core');
+    }
+}

--- a/Modules/Core/composer.json
+++ b/Modules/Core/composer.json
@@ -9,17 +9,18 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
-            "aliases": {
-
-            }
+            "providers": [
+                "Modules\\Core\\Providers\\CoreServiceProvider"
+            ],
+            "aliases": {}
         }
     },
     "autoload": {
         "psr-4": {
             "Modules\\Core\\": "app/",
             "Modules\\Core\\Database\\Factories\\": "database/factories/",
-            "Modules\\Core\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Core\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Core\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Crm/Providers/CrmServiceProvider.php
+++ b/Modules/Crm/Providers/CrmServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Crm\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class CrmServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'crm');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'crm');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'crm');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'crm');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Crm\\View\\Components', 'crm');
+    }
+}

--- a/Modules/Crm/composer.json
+++ b/Modules/Crm/composer.json
@@ -9,17 +9,18 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
-            "aliases": {
-
-            }
+            "providers": [
+                "Modules\\Crm\\Providers\\CrmServiceProvider"
+            ],
+            "aliases": {}
         }
     },
     "autoload": {
         "psr-4": {
             "Modules\\Crm\\": "app/",
             "Modules\\Crm\\Database\\Factories\\": "database/factories/",
-            "Modules\\Crm\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Crm\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Crm\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Dashboard/Providers/DashboardServiceProvider.php
+++ b/Modules/Dashboard/Providers/DashboardServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Dashboard\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class DashboardServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'dashboard');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'dashboard');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'dashboard');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'dashboard');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Dashboard\\View\\Components', 'dashboard');
+    }
+}

--- a/Modules/Dashboard/composer.json
+++ b/Modules/Dashboard/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\Dashboard\\Providers\\DashboardServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\Dashboard\\": "app/",
             "Modules\\Dashboard\\Database\\Factories\\": "database/factories/",
-            "Modules\\Dashboard\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Dashboard\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Dashboard\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/EnergyTracking/Providers/EnergyTrackingServiceProvider.php
+++ b/Modules/EnergyTracking/Providers/EnergyTrackingServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\EnergyTracking\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class EnergyTrackingServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'energytracking');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'energytracking');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'energytracking');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'energytracking');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\EnergyTracking\\View\\Components', 'energytracking');
+    }
+}

--- a/Modules/EnergyTracking/composer.json
+++ b/Modules/EnergyTracking/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\EnergyTracking\\Providers\\EnergyTrackingServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\EnergyTracking\\": "app/",
             "Modules\\EnergyTracking\\Database\\Factories\\": "database/factories/",
-            "Modules\\EnergyTracking\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\EnergyTracking\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\EnergyTracking\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/EquipmentLeasing/Providers/EquipmentLeasingServiceProvider.php
+++ b/Modules/EquipmentLeasing/Providers/EquipmentLeasingServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\EquipmentLeasing\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class EquipmentLeasingServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'equipmentleasing');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'equipmentleasing');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'equipmentleasing');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'equipmentleasing');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\EquipmentLeasing\\View\\Components', 'equipmentleasing');
+    }
+}

--- a/Modules/EquipmentLeasing/composer.json
+++ b/Modules/EquipmentLeasing/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\EquipmentLeasing\\Providers\\EquipmentLeasingServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\EquipmentLeasing\\": "app/",
             "Modules\\EquipmentLeasing\\Database\\Factories\\": "database/factories/",
-            "Modules\\EquipmentLeasing\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\EquipmentLeasing\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\EquipmentLeasing\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/EquipmentMaintenance/Providers/EquipmentMaintenanceServiceProvider.php
+++ b/Modules/EquipmentMaintenance/Providers/EquipmentMaintenanceServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\EquipmentMaintenance\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class EquipmentMaintenanceServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'equipmentmaintenance');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'equipmentmaintenance');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'equipmentmaintenance');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'equipmentmaintenance');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\EquipmentMaintenance\\View\\Components', 'equipmentmaintenance');
+    }
+}

--- a/Modules/EquipmentMaintenance/composer.json
+++ b/Modules/EquipmentMaintenance/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\EquipmentMaintenance\\Providers\\EquipmentMaintenanceServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\EquipmentMaintenance\\": "app/",
             "Modules\\EquipmentMaintenance\\Database\\Factories\\": "database/factories/",
-            "Modules\\EquipmentMaintenance\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\EquipmentMaintenance\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\EquipmentMaintenance\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/EquipmentMonitoring/Providers/EquipmentMonitoringServiceProvider.php
+++ b/Modules/EquipmentMonitoring/Providers/EquipmentMonitoringServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\EquipmentMonitoring\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class EquipmentMonitoringServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'equipmentmonitoring');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'equipmentmonitoring');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'equipmentmonitoring');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'equipmentmonitoring');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\EquipmentMonitoring\\View\\Components', 'equipmentmonitoring');
+    }
+}

--- a/Modules/EquipmentMonitoring/composer.json
+++ b/Modules/EquipmentMonitoring/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\EquipmentMonitoring\\Providers\\EquipmentMonitoringServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\EquipmentMonitoring\\": "app/",
             "Modules\\EquipmentMonitoring\\Database\\Factories\\": "database/factories/",
-            "Modules\\EquipmentMonitoring\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\EquipmentMonitoring\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\EquipmentMonitoring\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/EventManagement/Providers/EventManagementServiceProvider.php
+++ b/Modules/EventManagement/Providers/EventManagementServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\EventManagement\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class EventManagementServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'eventmanagement');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'eventmanagement');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'eventmanagement');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'eventmanagement');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\EventManagement\\View\\Components', 'eventmanagement');
+    }
+}

--- a/Modules/EventManagement/composer.json
+++ b/Modules/EventManagement/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\EventManagement\\Providers\\EventManagementServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\EventManagement\\": "app/",
             "Modules\\EventManagement\\Database\\Factories\\": "database/factories/",
-            "Modules\\EventManagement\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\EventManagement\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\EventManagement\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/FloorPlanDesigner/Providers/FloorPlanDesignerServiceProvider.php
+++ b/Modules/FloorPlanDesigner/Providers/FloorPlanDesignerServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\FloorPlanDesigner\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class FloorPlanDesignerServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'floorplandesigner');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'floorplandesigner');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'floorplandesigner');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'floorplandesigner');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\FloorPlanDesigner\\View\\Components', 'floorplandesigner');
+    }
+}

--- a/Modules/FloorPlanDesigner/composer.json
+++ b/Modules/FloorPlanDesigner/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\FloorPlanDesigner\\Providers\\FloorPlanDesignerServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\FloorPlanDesigner\\": "app/",
             "Modules\\FloorPlanDesigner\\Database\\Factories\\": "database/factories/",
-            "Modules\\FloorPlanDesigner\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\FloorPlanDesigner\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\FloorPlanDesigner\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/FoodSafety/Providers/FoodSafetyServiceProvider.php
+++ b/Modules/FoodSafety/Providers/FoodSafetyServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\FoodSafety\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class FoodSafetyServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'foodsafety');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'foodsafety');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'foodsafety');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'foodsafety');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\FoodSafety\\View\\Components', 'foodsafety');
+    }
+}

--- a/Modules/FoodSafety/composer.json
+++ b/Modules/FoodSafety/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\FoodSafety\\Providers\\FoodSafetyServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\FoodSafety\\": "app/",
             "Modules\\FoodSafety\\Database\\Factories\\": "database/factories/",
-            "Modules\\FoodSafety\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\FoodSafety\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\FoodSafety\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Franchise/Providers/FranchiseServiceProvider.php
+++ b/Modules/Franchise/Providers/FranchiseServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Franchise\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class FranchiseServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'franchise');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'franchise');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'franchise');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'franchise');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Franchise\\View\\Components', 'franchise');
+    }
+}

--- a/Modules/Franchise/composer.json
+++ b/Modules/Franchise/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\Franchise\\Providers\\FranchiseServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\Franchise\\": "app/",
             "Modules\\Franchise\\Database\\Factories\\": "database/factories/",
-            "Modules\\Franchise\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Franchise\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Franchise\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/HotelPms/Providers/HotelPmsServiceProvider.php
+++ b/Modules/HotelPms/Providers/HotelPmsServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\HotelPms\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class HotelPmsServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'hotelpms');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'hotelpms');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'hotelpms');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'hotelpms');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\HotelPms\\View\\Components', 'hotelpms');
+    }
+}

--- a/Modules/HotelPms/composer.json
+++ b/Modules/HotelPms/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\HotelPms\\Providers\\HotelPmsServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\HotelPms\\": "app/",
             "Modules\\HotelPms\\Database\\Factories\\": "database/factories/",
-            "Modules\\HotelPms\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\HotelPms\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\HotelPms\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/HrJobs/Providers/HrJobsServiceProvider.php
+++ b/Modules/HrJobs/Providers/HrJobsServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\HrJobs\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class HrJobsServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'hrjobs');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'hrjobs');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'hrjobs');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'hrjobs');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\HrJobs\\View\\Components', 'hrjobs');
+    }
+}

--- a/Modules/HrJobs/composer.json
+++ b/Modules/HrJobs/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\HrJobs\\Providers\\HrJobsServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\HrJobs\\": "app/",
             "Modules\\HrJobs\\Database\\Factories\\": "database/factories/",
-            "Modules\\HrJobs\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\HrJobs\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\HrJobs\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Inventory/Providers/InventoryServiceProvider.php
+++ b/Modules/Inventory/Providers/InventoryServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Inventory\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class InventoryServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'inventory');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'inventory');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'inventory');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'inventory');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Inventory\\View\\Components', 'inventory');
+    }
+}

--- a/Modules/Inventory/composer.json
+++ b/Modules/Inventory/composer.json
@@ -9,17 +9,18 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
-            "aliases": {
-
-            }
+            "providers": [
+                "Modules\\Inventory\\Providers\\InventoryServiceProvider"
+            ],
+            "aliases": {}
         }
     },
     "autoload": {
         "psr-4": {
             "Modules\\Inventory\\": "app/",
             "Modules\\Inventory\\Database\\Factories\\": "database/factories/",
-            "Modules\\Inventory\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Inventory\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Inventory\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Jobs/Providers/JobsServiceProvider.php
+++ b/Modules/Jobs/Providers/JobsServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Jobs\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class JobsServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'jobs');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'jobs');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'jobs');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'jobs');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Jobs\\View\\Components', 'jobs');
+    }
+}

--- a/Modules/Jobs/composer.json
+++ b/Modules/Jobs/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\Jobs\\Providers\\JobsServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\Jobs\\": "app/",
             "Modules\\Jobs\\Database\\Factories\\": "database/factories/",
-            "Modules\\Jobs\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Jobs\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Jobs\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Kds/Providers/KdsServiceProvider.php
+++ b/Modules/Kds/Providers/KdsServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Kds\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class KdsServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'kds');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'kds');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'kds');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'kds');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Kds\\View\\Components', 'kds');
+    }
+}

--- a/Modules/Kds/composer.json
+++ b/Modules/Kds/composer.json
@@ -9,17 +9,18 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
-            "aliases": {
-
-            }
+            "providers": [
+                "Modules\\Kds\\Providers\\KdsServiceProvider"
+            ],
+            "aliases": {}
         }
     },
     "autoload": {
         "psr-4": {
             "Modules\\Kds\\": "app/",
             "Modules\\Kds\\Database\\Factories\\": "database/factories/",
-            "Modules\\Kds\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Kds\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Kds\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Loyalty/Providers/LoyaltyServiceProvider.php
+++ b/Modules/Loyalty/Providers/LoyaltyServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Loyalty\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class LoyaltyServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'loyalty');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'loyalty');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'loyalty');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'loyalty');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Loyalty\\View\\Components', 'loyalty');
+    }
+}

--- a/Modules/Loyalty/composer.json
+++ b/Modules/Loyalty/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\Loyalty\\Providers\\LoyaltyServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\Loyalty\\": "app/",
             "Modules\\Loyalty\\Database\\Factories\\": "database/factories/",
-            "Modules\\Loyalty\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Loyalty\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Loyalty\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Marketplace/Providers/MarketplaceServiceProvider.php
+++ b/Modules/Marketplace/Providers/MarketplaceServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Marketplace\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class MarketplaceServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'marketplace');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'marketplace');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'marketplace');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'marketplace');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Marketplace\\View\\Components', 'marketplace');
+    }
+}

--- a/Modules/Marketplace/composer.json
+++ b/Modules/Marketplace/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\Marketplace\\Providers\\MarketplaceServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\Marketplace\\": "app/",
             "Modules\\Marketplace\\Database\\Factories\\": "database/factories/",
-            "Modules\\Marketplace\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Marketplace\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Marketplace\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Membership/Providers/MembershipServiceProvider.php
+++ b/Modules/Membership/Providers/MembershipServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Membership\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class MembershipServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'membership');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'membership');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'membership');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'membership');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Membership\\View\\Components', 'membership');
+    }
+}

--- a/Modules/Membership/composer.json
+++ b/Modules/Membership/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\Membership\\Providers\\MembershipServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\Membership\\": "app/",
             "Modules\\Membership\\Database\\Factories\\": "database/factories/",
-            "Modules\\Membership\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Membership\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Membership\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Notifications/Providers/NotificationsServiceProvider.php
+++ b/Modules/Notifications/Providers/NotificationsServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Notifications\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class NotificationsServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'notifications');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'notifications');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'notifications');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'notifications');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Notifications\\View\\Components', 'notifications');
+    }
+}

--- a/Modules/Notifications/composer.json
+++ b/Modules/Notifications/composer.json
@@ -9,16 +9,18 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
-            "aliases": {
-            }
+            "providers": [
+                "Modules\\Notifications\\Providers\\NotificationsServiceProvider"
+            ],
+            "aliases": {}
         }
     },
     "autoload": {
         "psr-4": {
             "Modules\\Notifications\\": "app/",
             "Modules\\Notifications\\Database\\Factories\\": "database/factories/",
-            "Modules\\Notifications\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Notifications\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Notifications\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Pos/Providers/PosServiceProvider.php
+++ b/Modules/Pos/Providers/PosServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Pos\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class PosServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'pos');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'pos');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'pos');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'pos');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Pos\\View\\Components', 'pos');
+    }
+}

--- a/Modules/Pos/composer.json
+++ b/Modules/Pos/composer.json
@@ -9,17 +9,18 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
-            "aliases": {
-
-            }
+            "providers": [
+                "Modules\\Pos\\Providers\\PosServiceProvider"
+            ],
+            "aliases": {}
         }
     },
     "autoload": {
         "psr-4": {
             "Modules\\Pos\\": "app/",
             "Modules\\Pos\\Database\\Factories\\": "database/factories/",
-            "Modules\\Pos\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Pos\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Pos\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Procurement/Providers/ProcurementServiceProvider.php
+++ b/Modules/Procurement/Providers/ProcurementServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Procurement\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class ProcurementServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'procurement');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'procurement');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'procurement');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'procurement');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Procurement\\View\\Components', 'procurement');
+    }
+}

--- a/Modules/Procurement/composer.json
+++ b/Modules/Procurement/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\Procurement\\Providers\\ProcurementServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\Procurement\\": "app/",
             "Modules\\Procurement\\Database\\Factories\\": "database/factories/",
-            "Modules\\Procurement\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Procurement\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Procurement\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/QrOrdering/Providers/QrOrderingServiceProvider.php
+++ b/Modules/QrOrdering/Providers/QrOrderingServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\QrOrdering\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class QrOrderingServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'qrordering');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'qrordering');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'qrordering');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'qrordering');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\QrOrdering\\View\\Components', 'qrordering');
+    }
+}

--- a/Modules/QrOrdering/composer.json
+++ b/Modules/QrOrdering/composer.json
@@ -5,7 +5,8 @@
         "psr-4": {
             "Modules\\QrOrdering\\": "app/",
             "Modules\\QrOrdering\\Database\\Factories\\": "database/factories/",
-            "Modules\\QrOrdering\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\QrOrdering\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\QrOrdering\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {
@@ -15,7 +16,9 @@
     },
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\QrOrdering\\Providers\\QrOrderingServiceProvider"
+            ],
             "aliases": {}
         }
     }

--- a/Modules/Rentals/Providers/RentalsServiceProvider.php
+++ b/Modules/Rentals/Providers/RentalsServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Rentals\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class RentalsServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'rentals');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'rentals');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'rentals');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'rentals');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Rentals\\View\\Components', 'rentals');
+    }
+}

--- a/Modules/Rentals/composer.json
+++ b/Modules/Rentals/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\Rentals\\Providers\\RentalsServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\Rentals\\": "app/",
             "Modules\\Rentals\\Database\\Factories\\": "database/factories/",
-            "Modules\\Rentals\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Rentals\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Rentals\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Reports/Providers/ReportsServiceProvider.php
+++ b/Modules/Reports/Providers/ReportsServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Reports\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class ReportsServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'reports');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'reports');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'reports');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'reports');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Reports\\View\\Components', 'reports');
+    }
+}

--- a/Modules/Reports/composer.json
+++ b/Modules/Reports/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\Reports\\Providers\\ReportsServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\Reports\\": "app/",
             "Modules\\Reports\\Database\\Factories\\": "database/factories/",
-            "Modules\\Reports\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Reports\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Reports\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/SelfServiceKiosk/Providers/SelfServiceKioskServiceProvider.php
+++ b/Modules/SelfServiceKiosk/Providers/SelfServiceKioskServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\SelfServiceKiosk\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class SelfServiceKioskServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'selfservicekiosk');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'selfservicekiosk');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'selfservicekiosk');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'selfservicekiosk');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\SelfServiceKiosk\\View\\Components', 'selfservicekiosk');
+    }
+}

--- a/Modules/SelfServiceKiosk/composer.json
+++ b/Modules/SelfServiceKiosk/composer.json
@@ -5,7 +5,8 @@
         "psr-4": {
             "Modules\\SelfServiceKiosk\\": "app/",
             "Modules\\SelfServiceKiosk\\Database\\Factories\\": "database/factories/",
-            "Modules\\SelfServiceKiosk\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\SelfServiceKiosk\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\SelfServiceKiosk\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {
@@ -15,7 +16,9 @@
     },
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\SelfServiceKiosk\\Providers\\SelfServiceKioskServiceProvider"
+            ],
             "aliases": {}
         }
     }

--- a/Modules/SuperAdmin/Providers/SuperAdminServiceProvider.php
+++ b/Modules/SuperAdmin/Providers/SuperAdminServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\SuperAdmin\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class SuperAdminServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'superadmin');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'superadmin');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'superadmin');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'superadmin');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\SuperAdmin\\View\\Components', 'superadmin');
+    }
+}

--- a/Modules/SuperAdmin/composer.json
+++ b/Modules/SuperAdmin/composer.json
@@ -9,16 +9,18 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
-            "aliases": {
-            }
+            "providers": [
+                "Modules\\SuperAdmin\\Providers\\SuperAdminServiceProvider"
+            ],
+            "aliases": {}
         }
     },
     "autoload": {
         "psr-4": {
             "Modules\\SuperAdmin\\": "app/",
             "Modules\\SuperAdmin\\Database\\Factories\\": "database/factories/",
-            "Modules\\SuperAdmin\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\SuperAdmin\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\SuperAdmin\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/TableReservations/Providers/TableReservationsServiceProvider.php
+++ b/Modules/TableReservations/Providers/TableReservationsServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\TableReservations\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class TableReservationsServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'tablereservations');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'tablereservations');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'tablereservations');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'tablereservations');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\TableReservations\\View\\Components', 'tablereservations');
+    }
+}

--- a/Modules/TableReservations/composer.json
+++ b/Modules/TableReservations/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\TableReservations\\Providers\\TableReservationsServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\TableReservations\\": "app/",
             "Modules\\TableReservations\\Database\\Factories\\": "database/factories/",
-            "Modules\\TableReservations\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\TableReservations\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\TableReservations\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {

--- a/Modules/Training/Providers/TrainingServiceProvider.php
+++ b/Modules/Training/Providers/TrainingServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Modules\Training\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class TrainingServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $modulePath = __DIR__ . '/../';
+
+        if (is_dir($modulePath . 'resources/views')) {
+            $this->loadViewsFrom($modulePath . 'resources/views', 'training');
+            Blade::anonymousComponentPath($modulePath . 'resources/views', 'training');
+            if (is_dir($modulePath . 'resources/views/components')) {
+                Blade::anonymousComponentPath($modulePath . 'resources/views/components', 'training');
+            }
+        }
+
+        if (is_dir($modulePath . 'resources/lang')) {
+            $this->loadTranslationsFrom($modulePath . 'resources/lang', 'training');
+        }
+
+        if (file_exists($modulePath . 'routes/web.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/web.php');
+        }
+
+        if (file_exists($modulePath . 'routes/api.php')) {
+            $this->loadRoutesFrom($modulePath . 'routes/api.php');
+        }
+
+        Blade::componentNamespace('Modules\\Training\\View\\Components', 'training');
+    }
+}

--- a/Modules/Training/composer.json
+++ b/Modules/Training/composer.json
@@ -9,7 +9,9 @@
     ],
     "extra": {
         "laravel": {
-            "providers": [],
+            "providers": [
+                "Modules\\Training\\Providers\\TrainingServiceProvider"
+            ],
             "aliases": {}
         }
     },
@@ -17,7 +19,8 @@
         "psr-4": {
             "Modules\\Training\\": "app/",
             "Modules\\Training\\Database\\Factories\\": "database/factories/",
-            "Modules\\Training\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\Training\\Database\\Seeders\\": "database/seeders/",
+            "Modules\\Training\\Providers\\": "Providers/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
## Summary
- add ServiceProvider to every module to load views, translations, routes and Blade components
- register providers via each module's composer.json for auto-discovery

## Testing
- `composer dump-autoload --no-scripts`
- `php artisan optimize:clear`
- `php artisan view:clear && php artisan view:cache`
- `php artisan route:list | head -n 20`
- Rendered `<x-core::components.layouts.master>` using a test view


------
https://chatgpt.com/codex/tasks/task_e_68c1f59145788332a1f90de263fd1d29