### PR TITLE
ci: set up Node 18 before installing dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: composer install --no-interaction --prefer-dist
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install Node dependencies
         run: npm ci
       - name: Composer audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
           extensions: mbstring, intl, pdo_mysql, dom, fileinfo
       - name: Install PHP dependencies
         run: composer install --no-interaction --prefer-dist
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
       - name: Install Node dependencies
         run: npm ci
       - name: Composer audit


### PR DESCRIPTION
## Summary
- setup Node 18 in CI workflow before installing Node packages

## Testing
- `npm test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c20668a660833292aae9ea22293bbb