### PR TITLE
ci: cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,19 @@ jobs:
         with:
           php-version: '8.3'
           extensions: mbstring, intl, pdo_mysql, dom, fileinfo
+      - uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       - name: Install PHP dependencies
         run: composer install --no-interaction --prefer-dist
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
       - name: Install Node dependencies
         run: npm ci
       - name: Composer audit


### PR DESCRIPTION
## Summary
- cache Composer dependencies to `vendor`
- cache npm packages to `~/.npm`

## Testing
- `npm test`
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68c20928a25c8332969b36876286af5b