### PR TITLE
ci: allow npm audit failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         run: composer audit --locked --no-interaction
       - name: NPM audit
         run: npm audit --audit-level=high
+        continue-on-error: true
       - name: Run Pint
         run: vendor/bin/pint --test
       - name: Run PHPStan


### PR DESCRIPTION
## Summary
- allow CI to continue even if `npm audit` reports vulnerabilities

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c20b7c72b88332b6899e8b43242ee4