### PR TITLE
Include TenantContext in tenant service tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
         </testsuite>
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
+            <exclude>./tests/Feature/FeatureTest.php</exclude>
         </testsuite>
     </testsuites>
     <source>

--- a/tests/Feature/FeatureTest.php
+++ b/tests/Feature/FeatureTest.php
@@ -7,7 +7,7 @@ use App\Models\User;
 use Database\Seeders\Testing\TestingDatabaseSeeder;
 use Tests\TestCase;
 
-class FeatureTest extends TestCase
+abstract class FeatureTest extends TestCase
 {
     protected static bool $setUpHasRunOnce = false;
 

--- a/tests/Feature/Services/TenantServiceTest.php
+++ b/tests/Feature/Services/TenantServiceTest.php
@@ -15,6 +15,7 @@ use App\Models\PlanPrice;
 use App\Models\Subscription;
 use App\Services\PaymentProviders\PaymentProviderInterface;
 use App\Services\PaymentProviders\PaymentService;
+use App\Services\TenantContext;
 use App\Services\TenantPermissionService;
 use App\Services\TenantService;
 use App\Services\TenantSubscriptionService;
@@ -73,6 +74,7 @@ class TenantServiceTest extends FeatureTest
         $tenantService = new TenantService(
             $permissionService,
             new TenantSubscriptionService($paymentService),
+            new TenantContext,
         );
 
         Event::fake();
@@ -137,6 +139,7 @@ class TenantServiceTest extends FeatureTest
         $tenantService = new TenantService(
             $permissionService,
             new TenantSubscriptionService($paymentService),
+            new TenantContext,
         );
 
         Event::fake();
@@ -202,6 +205,7 @@ class TenantServiceTest extends FeatureTest
         $tenantService = new TenantService(
             $permissionService,
             new TenantSubscriptionService($paymentService),
+            new TenantContext,
         );
 
         Event::fake();
@@ -255,6 +259,7 @@ class TenantServiceTest extends FeatureTest
         $tenantService = new TenantService(
             $permissionService,
             new TenantSubscriptionService($paymentService),
+            new TenantContext,
         );
 
         Event::fake();
@@ -316,6 +321,7 @@ class TenantServiceTest extends FeatureTest
         $tenantService = new TenantService(
             $permissionService,
             new TenantSubscriptionService($paymentService),
+            new TenantContext,
         );
 
         Event::fake();
@@ -371,6 +377,7 @@ class TenantServiceTest extends FeatureTest
         $tenantService = new TenantService(
             $permissionService,
             new TenantSubscriptionService($paymentService),
+            new TenantContext,
         );
 
         Event::fake();

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Tests\Unit;
-
-use PHPUnit\Framework\TestCase;
-
-class ExampleTest extends TestCase {}


### PR DESCRIPTION
## Summary
- inject TenantContext when constructing TenantService in tests
- mark FeatureTest base class as abstract and exclude from PHPUnit
- remove unused example unit test

## Testing
- `php -d memory_limit=1G ./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c4ddbd4a9c83328ef0a420cd8e1e8f