### PR TITLE
Add domain events and webhook listeners

### DIFF
--- a/app/Events/Device/DeviceAlert.php
+++ b/app/Events/Device/DeviceAlert.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Events\Device;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DeviceAlert
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public string $deviceId,
+        public string $message,
+    ) {}
+}

--- a/app/Events/Order/OrderCreated.php
+++ b/app/Events/Order/OrderCreated.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Events\Order;
+
+use App\Models\Order;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class OrderCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public Order $order) {}
+}

--- a/app/Events/Payment/PaymentFailed.php
+++ b/app/Events/Payment/PaymentFailed.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Events\Payment;
+
+use App\Models\Transaction;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PaymentFailed
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public Transaction $transaction) {}
+}

--- a/app/Events/Reservation/ReservationConfirmed.php
+++ b/app/Events/Reservation/ReservationConfirmed.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Events\Reservation;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ReservationConfirmed
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public array $reservation) {}
+}

--- a/app/Http/Controllers/Pos/ReservationController.php
+++ b/app/Http/Controllers/Pos/ReservationController.php
@@ -3,10 +3,13 @@
 namespace App\Http\Controllers\Pos;
 
 use App\Http\Controllers\Controller;
+use App\Services\ReservationService;
 use Illuminate\Http\Request;
 
 class ReservationController extends Controller
 {
+    public function __construct(private ReservationService $reservationService) {}
+
     /**
      * List reservations.
      */
@@ -20,7 +23,11 @@ class ReservationController extends Controller
      */
     public function store(Request $request)
     {
-        // TODO: implement reservation logic
-        return response()->json(['status' => 'ok']);
+        $reservation = $this->reservationService->confirm($request->all());
+
+        return response()->json([
+            'status' => 'confirmed',
+            'reservation' => $reservation,
+        ]);
     }
 }

--- a/app/Listeners/Device/SendDeviceAlertWebhook.php
+++ b/app/Listeners/Device/SendDeviceAlertWebhook.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Listeners\Device;
+
+use App\Events\Device\DeviceAlert;
+use App\Services\WebhookService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendDeviceAlertWebhook implements ShouldQueue
+{
+    public function __construct(private WebhookService $webhookService) {}
+
+    public function handle(DeviceAlert $event): void
+    {
+        $this->webhookService->send('device_alert', [
+            'device_id' => $event->deviceId,
+            'message' => $event->message,
+        ]);
+    }
+}

--- a/app/Listeners/Order/SendOrderCreatedWebhook.php
+++ b/app/Listeners/Order/SendOrderCreatedWebhook.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Listeners\Order;
+
+use App\Events\Order\OrderCreated;
+use App\Services\WebhookService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendOrderCreatedWebhook implements ShouldQueue
+{
+    public function __construct(private WebhookService $webhookService) {}
+
+    public function handle(OrderCreated $event): void
+    {
+        $this->webhookService->send('order_created', [
+            'order_uuid' => $event->order->uuid,
+        ]);
+    }
+}

--- a/app/Listeners/Payment/SendPaymentFailedWebhook.php
+++ b/app/Listeners/Payment/SendPaymentFailedWebhook.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Listeners\Payment;
+
+use App\Events\Payment\PaymentFailed;
+use App\Services\WebhookService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendPaymentFailedWebhook implements ShouldQueue
+{
+    public function __construct(private WebhookService $webhookService) {}
+
+    public function handle(PaymentFailed $event): void
+    {
+        $this->webhookService->send('payment_failed', [
+            'transaction_uuid' => $event->transaction->uuid,
+        ]);
+    }
+}

--- a/app/Listeners/Reservation/SendReservationConfirmedWebhook.php
+++ b/app/Listeners/Reservation/SendReservationConfirmedWebhook.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Listeners\Reservation;
+
+use App\Events\Reservation\ReservationConfirmed;
+use App\Services\WebhookService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendReservationConfirmedWebhook implements ShouldQueue
+{
+    public function __construct(private WebhookService $webhookService) {}
+
+    public function handle(ReservationConfirmed $event): void
+    {
+        $this->webhookService->send('reservation_confirmed', $event->reservation);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    protected $listen = [
+        \App\Events\SitemapChanged::class => [
+            \App\Listeners\GenerateSitemap::class,
+        ],
+        \App\Events\Order\Ordered::class => [
+            \App\Listeners\Order\SendOrderNotification::class,
+        ],
+        \App\Events\Subscription\InvoicePaymentFailed::class => [
+            \App\Listeners\Subscription\SendInvoicePaymentFailedNotification::class,
+        ],
+        \App\Events\Subscription\SubscriptionCancelled::class => [
+            \App\Listeners\Subscription\SendSubscriptionCancellationNotification::class,
+        ],
+        \App\Events\Subscription\Subscribed::class => [
+            \App\Listeners\Subscription\SendSubscribedNotification::class,
+        ],
+        \App\Events\Tenant\UserInvitedToTenant::class => [
+            \App\Listeners\Tenant\SendUserInvitationNotification::class,
+        ],
+        \App\Events\User\UserPhoneVerified::class => [
+            \App\Listeners\User\ActivateSubscriptionsPendingUserVerification::class,
+        ],
+        \App\Events\User\UserSeen::class => [
+            \App\Listeners\User\UpdateUserLastSeen::class,
+        ],
+        \Illuminate\Auth\Events\Registered::class => [
+            \App\Listeners\User\CreateTenantIfNeeded::class,
+        ],
+        \App\Events\Order\OrderCreated::class => [
+            \App\Listeners\Order\SendOrderCreatedWebhook::class,
+        ],
+        \App\Events\Payment\PaymentFailed::class => [
+            \App\Listeners\Payment\SendPaymentFailedWebhook::class,
+        ],
+        \App\Events\Device\DeviceAlert::class => [
+            \App\Listeners\Device\SendDeviceAlertWebhook::class,
+        ],
+        \App\Events\Reservation\ReservationConfirmed::class => [
+            \App\Listeners\Reservation\SendReservationConfirmedWebhook::class,
+        ],
+    ];
+}

--- a/app/Services/DeviceService.php
+++ b/app/Services/DeviceService.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Services;
+
+use App\Events\Device\DeviceAlert;
+
+class DeviceService
+{
+    public function alert(string $deviceId, string $message): void
+    {
+        DeviceAlert::dispatch($deviceId, $message);
+    }
+}

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -8,6 +8,7 @@ use App\Dto\CartDto;
 use App\Events\Order\Ordered;
 use App\Events\Order\OrderedOffline;
 use App\Events\Order\OrderRefunded;
+use App\Events\Order\OrderCreated;
 use App\Exceptions\TenantException;
 use App\Models\Currency;
 use App\Models\OneTimeProduct;
@@ -76,6 +77,8 @@ class OrderService
         if ($orderItems) {
             $order->items()->createMany($orderItems);
         }
+
+        OrderCreated::dispatch($order);
 
         if ($isLocal) {
             // if it's a local order, dispatch the Ordered event immediately

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Services;
+
+use App\Events\Reservation\ReservationConfirmed;
+
+class ReservationService
+{
+    public function confirm(array $data): array
+    {
+        ReservationConfirmed::dispatch($data);
+
+        return $data;
+    }
+}

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Constants\TransactionStatus;
+use App\Events\Payment\PaymentFailed;
 use App\Models\Currency;
 use App\Models\Order;
 use App\Models\PaymentProvider;
@@ -87,6 +88,10 @@ class TransactionService
         }
 
         $transaction->update($data);
+
+        if ($status === TransactionStatus::FAILED) {
+            PaymentFailed::dispatch($transaction);
+        }
 
         return $transaction;
     }

--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class WebhookService
+{
+    public function send(string $hook, array $payload): void
+    {
+        $url = config("services.webhooks.$hook");
+
+        if ($url) {
+            Http::post($url, $payload);
+        }
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -105,4 +105,11 @@ return [
         'from' => env('TWILIO_FROM'),
     ],
 
+    'webhooks' => [
+        'order_created' => env('WEBHOOK_ORDER_CREATED'),
+        'payment_failed' => env('WEBHOOK_PAYMENT_FAILED'),
+        'device_alert' => env('WEBHOOK_DEVICE_ALERT'),
+        'reservation_confirmed' => env('WEBHOOK_RESERVATION_CONFIRMED'),
+    ],
+
 ];

--- a/tests/Feature/Services/OrderServiceTest.php
+++ b/tests/Feature/Services/OrderServiceTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Services;
 
 use App\Constants\OrderStatus;
 use App\Events\Order\Ordered;
+use App\Events\Order\OrderCreated;
 use App\Models\Currency;
 use App\Models\OneTimeProduct;
 use App\Models\Order;
@@ -291,6 +292,7 @@ class OrderServiceTest extends FeatureTest
         ]);
 
         Event::assertDispatched(Ordered::class);
+        Event::assertDispatched(OrderCreated::class);
 
         $this->assertInstanceOf(Order::class, $order);
         $this->assertEquals(OrderStatus::SUCCESS->value, $order->status); // Local orders are successful immediately

--- a/tests/Feature/Services/TransactionServiceTest.php
+++ b/tests/Feature/Services/TransactionServiceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use App\Constants\TransactionStatus;
+use App\Events\Payment\PaymentFailed;
+use App\Models\Currency;
+use App\Models\PaymentProvider;
+use App\Models\Transaction;
+use App\Services\TransactionService;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use Tests\Feature\FeatureTest;
+
+class TransactionServiceTest extends FeatureTest
+{
+    public function test_dispatches_payment_failed_event(): void
+    {
+        Event::fake();
+
+        $user = $this->createUser();
+        $tenant = $this->createTenant();
+        $currency = Currency::first();
+        $provider = PaymentProvider::first();
+
+        $transaction = Transaction::create([
+            'uuid' => (string) Str::uuid(),
+            'user_id' => $user->id,
+            'amount' => 100,
+            'total_tax' => 0,
+            'total_discount' => 0,
+            'total_fees' => 0,
+            'currency_id' => $currency->id,
+            'status' => TransactionStatus::PENDING->value,
+            'payment_provider_id' => $provider->id,
+            'payment_provider_status' => 'pending',
+            'payment_provider_transaction_id' => 'tx_1',
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $service = app()->make(TransactionService::class);
+        $service->updateTransaction($transaction, 'failed', TransactionStatus::FAILED);
+
+        Event::assertDispatched(PaymentFailed::class, function ($event) use ($transaction) {
+            return $event->transaction->id === $transaction->id;
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add OrderCreated, PaymentFailed, DeviceAlert, and ReservationConfirmed events
- create listeners that send webhook payloads for each new event
- dispatch events from domain services and wire them in a new EventServiceProvider

## Testing
- `php -d memory_limit=512M ./vendor/bin/phpunit` *(fails: ArgumentCountError in TenantServiceTest)*

------
https://chatgpt.com/codex/tasks/task_e_68c4de244c6c8332891b0bfa08cdee4f