### PR TITLE
feat: safeguard cashier shortcuts

### DIFF
--- a/Modules/Pos/resources/js/cashier.js
+++ b/Modules/Pos/resources/js/cashier.js
@@ -2,11 +2,19 @@ document.addEventListener('alpine:init', () => {
     Alpine.data('cashierShortcuts', () => ({
         register() {
             window.addEventListener('keydown', (event) => {
+                if (event.repeat) {
+                    return;
+                }
+
                 if (event.key === 'F2') {
+                    event.preventDefault();
+                    event.stopPropagation();
                     this.$dispatch('cashier-checkout');
                 }
 
                 if (event.key === 'F4') {
+                    event.preventDefault();
+                    event.stopPropagation();
                     this.$dispatch('cashier-clear-cart');
                 }
             });


### PR DESCRIPTION
## Summary
- prevent repeat keydown events in cashier shortcuts
- stop default actions and propagation before dispatching F2 and F4 actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ed9f65b88332b5ca99362538cc0f