### PR TITLE
Restore default Laravel providers to enable test tooling

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\ServiceProvider;
 
 return [
 
@@ -227,9 +228,9 @@ return [
     |
     */
 
-    'providers' => [
+    'providers' => ServiceProvider::defaultProviders()->merge([
         Modules\Pos\Providers\PosServiceProvider::class,
-    ],
+    ])->toArray(),
 
     'aliases' => Facade::defaultAliases()->merge([
         // 'Example' => App\Facades\Example::class,


### PR DESCRIPTION
## Summary
- import ServiceProvider and merge Laravel's default providers in config

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Tests: 202, Assertions: 0, Errors: 202)*

------
https://chatgpt.com/codex/tasks/task_e_68c4edfa48d0833296d839f729daf9c4