### PR TITLE
Ensure cashier keyboard shortcuts are cleaned up

### DIFF
--- a/Modules/Pos/resources/js/cashier.js
+++ b/Modules/Pos/resources/js/cashier.js
@@ -1,7 +1,9 @@
 function registerCashierShortcuts() {
     window.Alpine.data('cashierShortcuts', () => ({
+        handler: null,
+
         register() {
-            window.addEventListener('keydown', (event) => {
+            this.handler = (event) => {
                 if (event.key === 'F2') {
                     this.$dispatch('cashier-checkout');
                 }
@@ -9,7 +11,15 @@ function registerCashierShortcuts() {
                 if (event.key === 'F4') {
                     this.$dispatch('cashier-clear-cart');
                 }
-            });
+            };
+
+            window.addEventListener('keydown', this.handler);
+        },
+
+        destroy() {
+            if (this.handler) {
+                window.removeEventListener('keydown', this.handler);
+            }
         },
     }));
 }


### PR DESCRIPTION
## Summary
- store cashier keydown handler and remove it when component is destroyed

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ee26d4b083329ce50f97488b7235